### PR TITLE
Add missing returns

### DIFF
--- a/wp-graphql-yoast-seo.php
+++ b/wp-graphql-yoast-seo.php
@@ -53,18 +53,18 @@ add_action('graphql_init', function () {
     {
 
       if (empty($images)) {
-        __return_empty_string();
+        return __return_empty_string();
       }
 
       $image  = reset($images);
 
       if (empty($image)) {
-        __return_empty_string();
+        return __return_empty_string();
       }
 
 
       if (!isset($image['url'])) {
-        __return_empty_string();
+        return __return_empty_string();
       }
 
       return attachment_url_to_postid($image['url']);


### PR DESCRIPTION
Without the "return" in the conditions, attachment_url_to_postid($image['url']) will still fire. Causes a PHP notice on some use cases.

```
 PHP Notice:  Trying to access array offset on value of type bool in ./wp-content/plugins/wp-graphql-yoast-seo/wp-graphql-yoast-seo.php on line 70
```