### PR TITLE
Remove Yoast SEO requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,6 @@
         "email": "hello@ashleyhitchcock.co.uk"
     }],
     "require": {
-        "wp-graphql/wp-graphql": ">=0.3.8",
-        "yoast/wordpress-seo": ">=14.0"
+        "wp-graphql/wp-graphql": ">=0.3.8"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "email": "hello@ashleyhitchcock.co.uk"
     }],
     "suggest": {
-        "wp-graphql/wp-graphql": ">=0.3.8"
+        "wp-graphql/wp-graphql": ">=0.3.8",
         "yoast/wordpress-seo": ">=14.0"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,8 @@
         "name": "Ash Hitchcock",
         "email": "hello@ashleyhitchcock.co.uk"
     }],
-    "require": {
+    "suggest": {
         "wp-graphql/wp-graphql": ">=0.3.8"
+        "yoast/wordpress-seo": ">=14.0"
     }
 }


### PR DESCRIPTION
We're using this plugin with Bedrock and Yoast SEO Premium. Including Yoast SEO as a requirement is causing both versions to get installed. It's not the end of the world, but since the plugin already checks to see that Yoast is installed this might not be necessary.