### PR TITLE
Detects Yoast Premium as a required dependency

### DIFF
--- a/wp-graphql-yoast-seo.php
+++ b/wp-graphql-yoast-seo.php
@@ -23,7 +23,7 @@ use WPGraphQL\Data\DataSource;
 add_action('admin_init', function () {
     $core_dependencies = [
         'WPGraphQL plugin' => class_exists('WPGraphQL'),
-        'Yoast SEO' => function_exists('YoastSEO'),
+        'Yoast SEO' => class_exists('WPSEO_Options'),
     ];
 
     $missing_dependencies = array_keys(


### PR DESCRIPTION
Fixes the following error message appearing when Yoast Premium is active.

"The WPGraphQL Yoast SEO plugin can't be loaded because these dependencies are missing:
Yoast SEO"

It now looks for the class WPSEO_Options which is always available when either version of the plugin is installed.