### PR TITLE
Replaced Site URL with Home Url for schema SiteUrl

### DIFF
--- a/wp-graphql-yoast-seo.php
+++ b/wp-graphql-yoast-seo.php
@@ -724,7 +724,7 @@ add_action('graphql_init', function () {
                             get_bloginfo('name')
                         ),
                         'siteUrl' => wp_gql_seo_format_string(
-                            apply_filters('wp_gql_seo_site_url', get_site_url())
+                            apply_filters('wp_gql_seo_site_url', get_home_url())
                         ),
                         'inLanguage' => wp_gql_seo_format_string(
                             get_bloginfo('language')


### PR DESCRIPTION
**Issue:**
If querying the SEO schema for the site `siteUrl` currently returns the site_url which is used for the WordPress Admin. When the WordPress admin sits in a different location (eg. Bedrock) OR is used as a headless environment `get_site_url` will return the admin URL

**Solution:**
replacing `get_site_url` with `get_home_url` will return the frontend domain instead.