### PR TITLE
Image optimize perf

### DIFF
--- a/wp-graphql-yoast-seo.php
+++ b/wp-graphql-yoast-seo.php
@@ -82,6 +82,10 @@ add_action('graphql_init', function () {
                 '$1.$2',
                 $image['url']
             );
+            // If the image is equal as the original and the original has an id, return this ID
+            if (isset($image['id']) && $url === $image['url']) {
+               return $image['id'];
+            }
             return wpcom_vip_attachment_url_to_postid($url);
         }
     }

--- a/wp-graphql-yoast-seo.php
+++ b/wp-graphql-yoast-seo.php
@@ -911,10 +911,14 @@ add_action('graphql_init', function () {
                                         $post,
                                         $context
                                     ) {
-                                        $id = wpcom_vip_attachment_url_to_postid(
-                                            YoastSEO()->meta->for_post($post->ID)
-                                                ->twitter_image
+                                        $twitter_image = YoastSEO()->meta->for_post($post->ID)
+                                                ->twitter_image;
+
+                                        if (empty($twitter_image)) {
+                                            return __return_empty_string();
                                         );
+
+                                        $id = wpcom_vip_attachment_url_to_postid($twitter_image);
 
                                         return $context
                                             ->get_loader('post')


### PR DESCRIPTION
`attachment_url_to_postid` can be really slow on big website.

Even if we are supposed to cache this with `wp_cache_set()`, we can short-circuit it before