### PR TITLE
Update openGraph frontPage support

### DIFF
--- a/wp-graphql-yoast-seo.php
+++ b/wp-graphql-yoast-seo.php
@@ -783,15 +783,15 @@ add_action('graphql_init', function () {
                             ->load_deferred(absint($all['og_default_image_id'])),
                         'frontPage' => [
                             'title' => wp_gql_seo_format_string(
-                                $all['og_frontpage_title']
+                                $all['open_graph_frontpage_title']
                             ),
                             'description' => wp_gql_seo_format_string(
-                                $all['og_frontpage_desc']
+                                $all['open_graph_frontpage_desc']
                             ),
                             'image' => $context
                                 ->get_loader('post')
                                 ->load_deferred(
-                                    absint($all['og_frontpage_image_id'])
+                                    absint($all['open_graph_frontpage_image_id'])
                             ),
 	                        'fullHead' => is_string(
                                     YoastSEO()

--- a/wp-graphql-yoast-seo.php
+++ b/wp-graphql-yoast-seo.php
@@ -494,6 +494,7 @@ add_action('graphql_init', function () {
                 'title' => ['type' => 'String'],
                 'description' => ['type' => 'String'],
                 'image' => ['type' => 'MediaItem'],
+                'fullHead' => ['type' => 'String']
             ],
         ]);
 
@@ -791,7 +792,18 @@ add_action('graphql_init', function () {
                                 ->get_loader('post')
                                 ->load_deferred(
                                     absint($all['og_frontpage_image_id'])
-                                ),
+                            ),
+	                        'fullHead' => is_string(
+                                    YoastSEO()
+                                        ->meta->for_home_page()
+                                        ->get_head()
+                                )
+                                    ? YoastSEO()
+                                        ->meta->for_home_page()
+                                        ->get_head()
+                                    : YoastSEO()
+                                        ->meta->for_home_page()
+                                        ->get_head()->html,
                         ],
                     ],
                 ];

--- a/wp-graphql-yoast-seo.php
+++ b/wp-graphql-yoast-seo.php
@@ -57,7 +57,13 @@ add_action('graphql_init', function () {
     if (!function_exists('wp_gql_seo_format_string')) {
         function wp_gql_seo_format_string($string)
         {
-            return isset($string) ? html_entity_decode(wpseo_replace_vars(trim($string),'post')) : null;
+            // Get all the post types that have been registered.
+            $post_types = get_post_types();
+            // Get all the taxonomies that have been registered.
+            $taxomonies = get_taxonomies();
+            // Merge them together and pass them through.
+            $objects    = array_merge($post_types,$taxomonies);
+            return isset($string) ? html_entity_decode(wpseo_replace_vars(trim($string),$objects)) : null;
         }
     }
     if (!function_exists('wp_gql_seo_get_og_image')) {

--- a/wp-graphql-yoast-seo.php
+++ b/wp-graphql-yoast-seo.php
@@ -57,7 +57,7 @@ add_action('graphql_init', function () {
     if (!function_exists('wp_gql_seo_format_string')) {
         function wp_gql_seo_format_string($string)
         {
-            return isset($string) ? html_entity_decode(trim($string)) : null;
+            return isset($string) ? html_entity_decode(wpseo_replace_vars(trim($string),'post')) : null;
         }
     }
     if (!function_exists('wp_gql_seo_get_og_image')) {

--- a/wp-graphql-yoast-seo.php
+++ b/wp-graphql-yoast-seo.php
@@ -57,13 +57,20 @@ add_action('graphql_init', function () {
     if (!function_exists('wp_gql_seo_format_string')) {
         function wp_gql_seo_format_string($string)
         {
+            return isset($string) ? html_entity_decode(trim($string)) : null;
+        }
+    }
+
+    if (!function_exists('wp_gql_seo_replace_vars')) {
+        function wp_gql_seo_replace_vars($string)
+        {
             // Get all the post types that have been registered.
             $post_types = get_post_types();
             // Get all the taxonomies that have been registered.
             $taxomonies = get_taxonomies();
             // Merge them together and pass them through.
-            $objects    = array_merge($post_types,$taxomonies);
-            return isset($string) ? html_entity_decode(wpseo_replace_vars(trim($string),$objects)) : null;
+            $objects = array_merge($post_types, $taxomonies);
+            return isset($string) ? wpseo_replace_vars($string, $objects) : null;
         }
     }
     if (!function_exists('wp_gql_seo_get_og_image')) {
@@ -185,10 +192,14 @@ add_action('graphql_init', function () {
 
                 $carry[$tag] = [
                     'title' => !empty($all['title-' . $type])
-                        ? $all['title-' . $type]
+                        ? wp_gql_seo_format_string(
+                            wp_gql_seo_replace_vars($all['title-' . $type])
+                        )
                         : null,
                     'metaDesc' => !empty($all['metadesc-' . $type])
-                        ? $all['metadesc-' . $type]
+                        ? wp_gql_seo_format_string(
+                            wp_gql_seo_replace_vars($all['metadesc-' . $type])
+                        )
                         : null,
                     'metaRobotsNoindex' => !empty($all['noindex-' . $type])
                         ? boolval($all['noindex-' . $type])
@@ -208,10 +219,18 @@ add_action('graphql_init', function () {
                                 'hasArchive' => true,
                                 'archiveLink' => get_post_type_archive_link($type),
                                 'title' => !empty($all['title-archive-wpseo'])
-                                    ? $all['title-archive-wpseo']
+                                    ? wp_gql_seo_format_string(
+                                        wp_gql_seo_replace_vars(
+                                            $all['title-archive-wpseo']
+                                        )
+                                    )
                                     : null,
                                 'metaDesc' => !empty($all['metadesc-archive-wpseo'])
-                                    ? $all['metadesc-archive-wpseo']
+                                    ? wp_gql_seo_format_string(
+                                        wp_gql_seo_replace_vars(
+                                            $all['metadesc-archive-wpseo']
+                                        )
+                                    )
                                     : null,
                                 'metaRobotsNoindex' => !empty(
                                     $all['noindex-archive-wpseo']
@@ -788,16 +807,20 @@ add_action('graphql_init', function () {
                             ->load_deferred(absint($all['og_default_image_id'])),
                         'frontPage' => [
                             'title' => wp_gql_seo_format_string(
-                                $all['open_graph_frontpage_title']
+                                wp_gql_seo_replace_vars(
+                                    $all['open_graph_frontpage_title']
+                                )
                             ),
                             'description' => wp_gql_seo_format_string(
-                                $all['open_graph_frontpage_desc']
+                                wp_gql_seo_replace_vars(
+                                    $all['open_graph_frontpage_desc']
+                                )
                             ),
                             'image' => $context
                                 ->get_loader('post')
                                 ->load_deferred(
                                     absint($all['open_graph_frontpage_image_id'])
-                            ),
+                                ),
                         ],
                     ],
                 ];
@@ -866,31 +889,45 @@ add_action('graphql_init', function () {
                                     'metaRobotsNoindex' => $robots['index'] ?? '',
                                     'metaRobotsNofollow' => $robots['follow'] ?? '',
                                     'opengraphTitle' => wp_gql_seo_format_string(
-                                        $meta !== false ? $meta->open_graph_title : ''
+                                        $meta !== false
+                                            ? $meta->open_graph_title
+                                            : ''
                                     ),
                                     'opengraphUrl' => wp_gql_seo_format_string(
                                         $meta !== false ? $meta->open_graph_url : ''
                                     ),
                                     'opengraphSiteName' => wp_gql_seo_format_string(
-                                        $meta !== false ? $meta->open_graph_site_name : ''
+                                        $meta !== false
+                                            ? $meta->open_graph_site_name
+                                            : ''
                                     ),
                                     'opengraphType' => wp_gql_seo_format_string(
                                         $meta !== false ? $meta->open_graph_type : ''
                                     ),
                                     'opengraphAuthor' => wp_gql_seo_format_string(
-                                        $meta !== false ? $meta->open_graph_article_author : ''
+                                        $meta !== false
+                                            ? $meta->open_graph_article_author
+                                            : ''
                                     ),
                                     'opengraphPublisher' => wp_gql_seo_format_string(
-                                        $meta !== false ? $meta->open_graph_article_publisher : ''
+                                        $meta !== false
+                                            ? $meta->open_graph_article_publisher
+                                            : ''
                                     ),
                                     'opengraphPublishedTime' => wp_gql_seo_format_string(
-                                        $meta !== false ? $meta->open_graph_article_published_time : ''
+                                        $meta !== false
+                                            ? $meta->open_graph_article_published_time
+                                            : ''
                                     ),
                                     'opengraphModifiedTime' => wp_gql_seo_format_string(
-                                        $meta !== false ? $meta->open_graph_article_modified_time : ''
+                                        $meta !== false
+                                            ? $meta->open_graph_article_modified_time
+                                            : ''
                                     ),
                                     'opengraphDescription' => wp_gql_seo_format_string(
-                                        $meta !== false ? $meta->open_graph_description : ''
+                                        $meta !== false
+                                            ? $meta->open_graph_description
+                                            : ''
                                     ),
                                     'opengraphImage' => function () use (
                                         $post,
@@ -898,7 +935,9 @@ add_action('graphql_init', function () {
                                         $meta
                                     ) {
                                         $id = wp_gql_seo_get_og_image(
-                                            $meta !== false ? $meta->open_graph_images : []
+                                            $meta !== false
+                                                ? $meta->open_graph_images
+                                                : []
                                         );
 
                                         return $context
@@ -912,7 +951,9 @@ add_action('graphql_init', function () {
                                         $meta !== false ? $meta->twitter_title : ''
                                     ),
                                     'twitterDescription' => wp_gql_seo_format_string(
-                                        $meta !== false ? $meta->twitter_description : ''
+                                        $meta !== false
+                                            ? $meta->twitter_description
+                                            : ''
                                     ),
                                     'twitterImage' => function () use (
                                         $post,
@@ -920,7 +961,9 @@ add_action('graphql_init', function () {
                                         $meta
                                     ) {
                                         $id = wpcom_vip_attachment_url_to_postid(
-                                            $meta !== false ? $meta->twitter_image : ''
+                                            $meta !== false
+                                                ? $meta->twitter_image
+                                                : ''
                                         );
 
                                         return $context
@@ -931,21 +974,30 @@ add_action('graphql_init', function () {
                                         $meta !== false ? $meta->canonical : ''
                                     ),
                                     'readingTime' => floatval(
-                                        $meta !== false ? $meta->estimated_reading_time_minutes : ''
+                                        $meta !== false
+                                            ? $meta->estimated_reading_time_minutes
+                                            : ''
                                     ),
-                                    'breadcrumbs' => $meta !== false ? $meta->breadcrumbs : [],
+                                    'breadcrumbs' =>
+                                        $meta !== false ? $meta->breadcrumbs : [],
                                     // TODO: Default should be true or false?
                                     'cornerstone' => boolval(
-                                        $meta !== false ? $meta->indexable->is_cornerstone : false,
+                                        $meta !== false
+                                            ? $meta->indexable->is_cornerstone
+                                            : false
                                     ),
                                     'fullHead' => wp_gql_seo_get_full_head($meta),
                                     'schema' => [
-                                        'pageType' => $meta !== false && is_array($meta->schema_page_type)
-                                            ? $meta->schema_page_type
-                                            : [],
-                                        'articleType' => $meta !== false && is_array($meta->schema_article_type)
-                                            ? $meta->schema_article_type
-                                            : [],
+                                        'pageType' =>
+                                            $meta !== false &&
+                                            is_array($meta->schema_page_type)
+                                                ? $meta->schema_page_type
+                                                : [],
+                                        'articleType' =>
+                                            $meta !== false &&
+                                            is_array($meta->schema_article_type)
+                                                ? $meta->schema_article_type
+                                                : [],
                                         'raw' => json_encode(
                                             $schemaArray,
                                             JSON_UNESCAPED_SLASHES

--- a/wp-graphql-yoast-seo.php
+++ b/wp-graphql-yoast-seo.php
@@ -494,7 +494,6 @@ add_action('graphql_init', function () {
                 'title' => ['type' => 'String'],
                 'description' => ['type' => 'String'],
                 'image' => ['type' => 'MediaItem'],
-                'fullHead' => ['type' => 'String']
             ],
         ]);
 
@@ -793,17 +792,6 @@ add_action('graphql_init', function () {
                                 ->load_deferred(
                                     absint($all['open_graph_frontpage_image_id'])
                             ),
-	                        'fullHead' => is_string(
-                                    YoastSEO()
-                                        ->meta->for_home_page()
-                                        ->get_head()
-                                )
-                                    ? YoastSEO()
-                                        ->meta->for_home_page()
-                                        ->get_head()
-                                    : YoastSEO()
-                                        ->meta->for_home_page()
-                                        ->get_head()->html,
                         ],
                     ],
                 ];


### PR DESCRIPTION
Hey @ashhitch, firstly, thanks so much for writing and maintaining this plugin. I've used it on a couple of headless WordPress projects now and it's saved me loads of time!

I've just been digging into a few things with the `frontPage` support you've added and I found a few bugs and improvements that we can add:

1. I noticed that placeholders that Yoast use weren't getting parsed so I've wrapped one of your functions so that's handled.
2. I noticed that Yoast SEO deprecated the keys for the [OG front page options](https://github.com/Yoast/wordpress-seo/blob/trunk/inc/class-upgrade.php#L1201-L1206) so I've updated those. N.B. The `og_default_image_id` key in `defaultImage` remains though.

## Screenshots

### Before Any Changes

<img width="2672" alt="GraphiQL_IDE__WPGraphQL_Chassis_Site_Title__WordPress_2022-03-15_12-53-38 (1)" src="https://user-images.githubusercontent.com/1377956/158297213-52bc66a6-a0ee-4b7f-b262-996e89bb0337.png">


### After changing keys but before adding `wpseo_replace_vars`

<img width="2672" alt="GraphiQL_IDE__WPGraphQL_Chassis_Site_Title__WordPress_2022-03-15_12-56-08" src="https://user-images.githubusercontent.com/1377956/158296902-0a040f0e-1077-4301-82f2-6dd6c7f58ef6.png">

### After All The Changes

<img width="2672" alt="GraphiQL_IDE__WPGraphQL_Chassis_Site_Title__WordPress_2022-03-15_12-52-01" src="https://user-images.githubusercontent.com/1377956/158296411-bc9faae3-8514-488b-becb-f23df7561fc3.png">


