### PR TITLE
Add guard against undefined user object

### DIFF
--- a/wp-graphql-yoast-seo.php
+++ b/wp-graphql-yoast-seo.php
@@ -740,9 +740,9 @@ add_action('graphql_init', function () {
                         'companyName' => wp_gql_seo_format_string(
                             $all['company_name']
                         ),
-                        'personName' => wp_gql_seo_format_string(
-                            $user->user_nicename
-                        ),
+                        'personName' => !empty($user)
+                            ? wp_gql_seo_format_string($user->user_nicename)
+                            : null,
                         'companyLogo' => $context
                             ->get_loader('post')
                             ->load_deferred(absint($all['company_logo_id'])),


### PR DESCRIPTION
Hi @ashhitch this is related to https://github.com/ashhitch/wp-graphql-yoast-seo/issues/118

I added a check on the user object to avoid the warning below.

```
PHP Notice:  Trying to get property 'user_nicename' of non-object in .../app/public/wp-content/plugins/headless/vendor/ashhitch/wp-graphql-yoast-seo/wp-graphql-yoast-seo.php on line 744
```

Thanks