### PR TITLE
Archive SEO enhancements

### DIFF
--- a/wp-graphql-yoast-seo.php
+++ b/wp-graphql-yoast-seo.php
@@ -205,8 +205,8 @@ add_action('graphql_init', function () {
                             'title' => !empty($meta->title)
                                 ? wp_gql_seo_format_string($meta->title)
                                 : null,
-                            'metaDesc' => !empty($meta->indexable->description)
-                                ? wp_gql_seo_format_string($meta->indexable->description)
+                            'metaDesc' => !empty($all['metadesc-ptarchive-' . $type])
+                                ? wp_gql_seo_format_string($all['metadesc-ptarchive-' . $type])
                                 : null,
                             'metaRobotsNoindex' => !empty($meta->robots['index']) && $meta->robots['index'] === 'index'
                                 ? false
@@ -220,8 +220,8 @@ add_action('graphql_init', function () {
                             'metaRobotsFollow' => !empty($meta->robots['follow'])
                                 ? $meta->robots['follow']
                                 : 'nofollow',
-                            'breadcrumbTitle' => !empty($meta->indexable->breadcrumb_title)
-                                ? $meta->indexable->breadcrumb_title
+                            'breadcrumbTitle' => !empty($all['bctitle-ptarchive-' . $type])
+                                ? wp_gql_seo_format_string($all['bctitle-ptarchive-' . $type])
                                 : null,
                             'fullHead' => is_string($meta->get_head())
                                 ? $meta->get_head()

--- a/wp-graphql-yoast-seo.php
+++ b/wp-graphql-yoast-seo.php
@@ -203,10 +203,10 @@ add_action('graphql_init', function () {
                             'hasArchive' => boolval($post_type_object->has_archive),
                             'archiveLink' => get_post_type_archive_link($type),
                             'title' => !empty($meta->title)
-                                ? $meta->title
+                                ? wp_gql_seo_format_string($meta->title)
                                 : null,
                             'metaDesc' => !empty($meta->indexable->description)
-                                ? $meta->indexable->description
+                                ? wp_gql_seo_format_string($meta->indexable->description)
                                 : null,
                             'metaRobotsNoindex' => !empty($meta->robots['index']) && $meta->robots['index'] === 'index'
                                 ? false

--- a/wp-graphql-yoast-seo.php
+++ b/wp-graphql-yoast-seo.php
@@ -190,7 +190,7 @@ add_action('graphql_init', function () {
                     'metaDesc' => !empty($all['metadesc-' . $type])
                         ? wp_gql_seo_format_string(wp_gql_seo_replace_vars($all['metadesc-' . $type]))
                         : null,
-                    'metaRobotsNoindex' => !empty($all['noindex-' . $type]) ? 'noindex' : 'index',
+                    'metaRobotsNoindex' => !empty($all['noindex-' . $type]) ? boolval($all['noindex-' . $type]) : false,
                     'schemaType' => !empty($all['schema-page-type-' . $type])
                         ? $all['schema-page-type-' . $type]
                         : null,
@@ -208,10 +208,16 @@ add_action('graphql_init', function () {
                             'metaDesc' => !empty($meta->indexable->description)
                                 ? $meta->indexable->description
                                 : null,
-                            'metaRobotsNoindex' => !empty($meta->robots['index'])
+                            'metaRobotsNoindex' => !empty($meta->robots['index']) && $meta->robots['index'] === 'index'
+                                ? false
+                                : true,
+                            'metaRobotsNofollow' => !empty($meta->robots['follow']) && $meta->robots['follow'] === 'follow'
+                                ? false
+                                : true,
+                            'metaRobotsIndex' => !empty($meta->robots['index'])
                                 ? $meta->robots['index']
                                 : 'noindex',
-                            'metaRobotsNofollow' => !empty($meta->robots['follow'])
+                            'metaRobotsFollow' => !empty($meta->robots['follow'])
                                 ? $meta->robots['follow']
                                 : 'nofollow',
                             'breadcrumbTitle' => !empty($meta->indexable->breadcrumb_title)
@@ -490,8 +496,10 @@ add_action('graphql_init', function () {
                 'title' => ['type' => 'String'],
                 'archiveLink' => ['type' => 'String'],
                 'metaDesc' => ['type' => 'String'],
-                'metaRobotsNoindex' => ['type' => 'String'],
-                'metaRobotsNofollow' => ['type' => 'String'],
+                'metaRobotsNoindex' => ['type' => 'Boolean'],
+                'metaRobotsNofollow' => ['type' => 'Boolean'],
+                'metaRobotsIndex' => ['type' => 'String'],
+                'metaRobotsFollow' => ['type' => 'String'],
                 'breadcrumbTitle' => ['type' => 'String'],
                 'fullHead' => ['type' => 'String'],
             ],
@@ -501,7 +509,7 @@ add_action('graphql_init', function () {
             'fields' => [
                 'title' => ['type' => 'String'],
                 'metaDesc' => ['type' => 'String'],
-                'metaRobotsNoindex' => ['type' => 'String'],
+                'metaRobotsNoindex' => ['type' => 'Boolean'],
                 'schemaType' => ['type' => 'String'],
                 'schema' => ['type' => 'SEOPageInfoSchema'],
                 'archive' => ['type' => 'SEOContentTypeArchive'],

--- a/wp-graphql-yoast-seo.php
+++ b/wp-graphql-yoast-seo.php
@@ -201,7 +201,7 @@ add_action('graphql_init', function () {
                     'archive' =>
                         [
                             'hasArchive' => boolval($post_type_object->has_archive),
-                            'archiveLink' => get_post_type_archive_link($type),
+                            'archiveLink' => apply_filters('wp_gql_seo_archive_link', get_post_type_archive_link($type)),
                             'title' => !empty($meta->title)
                                 ? wp_gql_seo_format_string($meta->title)
                                 : null,

--- a/wp-graphql-yoast-seo.php
+++ b/wp-graphql-yoast-seo.php
@@ -201,7 +201,7 @@ add_action('graphql_init', function () {
                     'archive' =>
                         [
                             'hasArchive' => boolval($post_type_object->has_archive),
-                            'archiveLink' => apply_filters('wp_gql_seo_archive_link', get_post_type_archive_link($type)),
+                            'archiveLink' => apply_filters('wp_gql_seo_archive_link', get_post_type_archive_link($type), $type),
                             'title' => !empty($meta->title)
                                 ? wp_gql_seo_format_string($meta->title)
                                 : null,


### PR DESCRIPTION
This PR complementary of #85 makes the following improvements to the archive SEO data by using [Yoast SEO surfaces](https://yoast.com/developer-blog/yoast-seo-14-0-using-yoast-seo-surfaces/).
- Show encoded title instead of Yoast SEO variables.
- Add the `metaRobotsNofollow` value even if it is not configurable from the Search Appearance to simplify integrations.
- Return a string instead of a boolean for the `metaRobotsNoindex` and `metaRobotsNofollow` values to keep it consistent across individual nodes.

While the API is well-documented [for current pages](https://developer.yoast.com/customization/apis/surfaces-api/), I didn't find a way to get the global values for individual pages. I'm also wondering if the `archiveLink` field should be renamed `canonical`.

### Before
![image](https://user-images.githubusercontent.com/11416255/203857934-45cbb64f-ef40-4712-8fd3-31661ac5c10a.png)

### After
![image](https://user-images.githubusercontent.com/11416255/203857945-afb5ac78-4f85-4f46-a799-97c82c07e0c7.png)