### PR TITLE
Set  to null instead of false

### DIFF
--- a/wp-graphql-yoast-seo.php
+++ b/wp-graphql-yoast-seo.php
@@ -130,6 +130,7 @@ add_action('graphql_init', function () {
                         'default',
                         12 * HOUR_IN_SECONDS + mt_rand(0, 4 * HOUR_IN_SECONDS) // phpcs:ignore
                     );
+                    $id = null; // Set $id to null instead of false
                 } else {
                     wp_cache_set(
                         $cache_key,
@@ -139,12 +140,12 @@ add_action('graphql_init', function () {
                     );
                 }
             } elseif ('not_found' === $id) {
-                return false;
+                return null; // Return null instead of false
             }
-
+    
             return $id;
         }
-    }
+    }    
 
     function wp_gql_seo_build_content_types($types)
     {


### PR DESCRIPTION
Cannot return null for non-nullable field "MediaItem.id"

Betting it has to do with this, where wpcom_vip_attachment_url_to_postid is returning false causing a 0 to be passed to the loader instead of bailing with null.
 $id = wpcom_vip_attachment_url_to_postid($twitter_image);

This fixes - [https://github.com/ashhitch/wp-graphql-yoast-seo/issues/132](https://github.com/ashhitch/wp-graphql-yoast-seo/issues/132)

----

### My Solution:

It's possible that the error message "Cannot return null for non-nullable field 'MediaItem.id'" is related to the fact that the `wpcom_vip_attachment_url_to_postid() `function is returning false when it fails to find a post ID for the given URL. This can cause the `$id` variable to be assigned a value of `false` instead of a valid post ID.

When the `$id `variable is later used in a GraphQL query/mutation as the ID of a `MediaItem` object, it's expected to be a non-null value. Since `false` is not a valid ID, the GraphQL server is throwing an error saying that it cannot return null for a non-nullable field.

To fix this issue, you could modify the `wpcom_vip_attachment_url_to_postid()` function to return `null` instead of `false` when it fails to find a post ID. Then, when` $id` is used in a GraphQL query/mutation, it will be null instead of false, which is an acceptable value for a nullable field.


By setting $id to null instead of false when a post ID cannot be found, you'll avoid the error message about returning null for a non-nullable field.

