### PR TITLE
Fix TwitterImage: Cannot return null for non-nullable field \"MediaItem.databaseId\"."

### DIFF
--- a/wp-graphql-yoast-seo.php
+++ b/wp-graphql-yoast-seo.php
@@ -800,7 +800,7 @@ add_action('graphql_init', function () {
                     $twitter_image = $meta->twitter_image;
 
                     if (empty($twitter_image)) {
-                        return __return_empty_string();
+                        return null;
                     }
 
                     $id = wpcom_vip_attachment_url_to_postid($twitter_image);


### PR DESCRIPTION
When no twitter image set, the resolver returned an empty string. This is not consistent with othe MediaItem fields, and make any non-nullable field in the MediaItem type throw an error.

![Capture d’écran 2023-04-28 à 10 04 04](https://user-images.githubusercontent.com/6989959/235092299-b53a18cb-473d-4a9f-a535-1cf2eea7bffb.png)

As you can see on the screenshots below, for `opengraphImage` field return null instead of an object with properties with empty string.

| opengraphImage returns null | twitterImage returns an object with empty string properties |
| ----------------------------- | ----------------------------------------------------------- |
|  ![Capture d’écran 2023-04-28 à 10 05 30](https://user-images.githubusercontent.com/6989959/235093028-f71d8b95-66e2-4365-bd45-348933187239.png) | ![Capture d’écran 2023-04-28 à 10 04 23](https://user-images.githubusercontent.com/6989959/235093142-e6b9b472-a68b-4eea-beab-a9cb3a207da9.png)  | 

This pull request fixes this and simply if not twitter image set, the property `twitterImage` will be null.

**=> after the fix**

![Capture d’écran 2023-04-28 à 10 14 32](https://user-images.githubusercontent.com/6989959/235093443-0d4e24ec-10c4-441d-b919-7c1583beb9c7.png)

