### PR TITLE
fix: Fix naming collision with vip-helpers plugin

### DIFF
--- a/includes/resolvers/post-type.php
+++ b/includes/resolvers/post-type.php
@@ -73,7 +73,7 @@ function wp_gql_seo_get_post_type_graphql_fields($post, array $args, AppContext 
                 return null;
             }
 
-            $id = wpcom_vip_attachment_url_to_postid($twitter_image);
+            $id = wp_gql_seo_attachment_url_to_postid($twitter_image);
 
             return $context->get_loader('post')->load_deferred(absint($id));
         },


### PR DESCRIPTION
Since this plugin copies function names from `vip-helpers`, it results in a fatal error due to the naming collision. `PHP Fatal error:  Cannot redeclare wpcom_vip_attachment_cache_key() (previously declared in /wp/wp-content/mu-plugins/vip-helpers/vip-caching.php:483) in /wp/wp-content/plugins/add-wpgraphql-seo/includes/helpers/functions.php on line 92;` This fixes that error by only defining those functions if they don't already exist. Preserves the fix from https://github.com/ashhitch/wp-graphql-yoast-seo/pull/154 by creating a wrapper function around `wpcom_vip_attachment_url_to_postid` to return `null` instead of `false`.

Fixes #189