### PR TITLE
feat: add comprehensive SEO fields and structured head output i

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -40,3 +40,4 @@ contributors.svg
 # Misc / scratch files
 new.json
 old.json
+all.graphql

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,7 +64,7 @@ wp-graphql-yoast-seo/
 - **WordPress**: 5.0+
 - **WPGraphQL**: Latest version
 - **Yoast SEO**: 14.0.0+
-- **PHP**: 7.4+
+- **PHP**: 7.1+
 
 ### Integration Points
 - Hooks into `graphql_init` action

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,40 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.1.0] - 2026-07-31
+
+### Added
+
+#### Per-object SEO fields (posts, terms, users)
+- `robots` object with `noindex`, `nofollow`, `noarchive`, `noimageindex`, `nosnippet` directives
+- `analysis` object with `keywordScore`, `readabilityScore`, `inclusiveLanguageScore`, `linkCount`, `incomingLinkCount`
+- `opengraphLocale`, `opengraphFbAppId`, `opengraphEnabled`
+- `twitterCreator`, `twitterSite`
+- `relNext`, `relPrev` pagination links
+- `breadcrumbTitle`, `objectPublishedAt`, `objectLastModified`, `language`, `region` per post/term
+- `mastodon` user social profile
+
+#### Structured head JSON
+- `head` object with `html` and `json` fields alongside the existing `fullHead` HTML string
+- Matches Yoast's own REST `/yoast/v1/get_head` endpoint output for headless consumers
+
+#### Global config gaps
+- `meta.search` with search results title
+- `meta.author.noindex`, `meta.author.noindexNoPosts`, `meta.date.noindex`
+- `contentTypes.{type}.articleType` (schema article type per post type)
+- `social.mastodon` global social profile
+- `social.twitter.enabled`, `openGraph.enabled` toggles
+- `advanced` block: `siteType`, `environmentType`, `hasMultipleAuthors`, `xmlSitemapEnabled`, `indexNowEnabled`, `indexNowKey`, `contentAnalysisActive`, `keywordAnalysisActive`, `inclusiveLanguageAnalysisActive`
+
+#### Premium social-per-archive (Yoast SEO Premium)
+- `SEOSocialArchive` type with `title`, `description`, `image`
+- `social` field on content type archives, taxonomy archives, author archives, and date archives
+- Graceful fallback to null when Premium is inactive (detected via option-key presence)
+
+### Fixed
+
+- Cache `YoastSEO()->meta->for_term()` result in taxonomy resolver instead of calling it repeatedly (N+1 fix)
+
 ## [5.0.3] - 2026-06-06
 
 ### Fixed

--- a/all.graphql
+++ b/all.graphql
@@ -1,0 +1,358 @@
+query TestAllFeatures {
+  # ─── POST SEO ───
+  posts(first: 1) {
+    edges {
+      node {
+        id
+        title
+        seo {
+          title
+          metaDesc
+          focuskw
+          metaKeywords
+          metaRobotsNoindex
+          metaRobotsNofollow
+          robots {
+            noindex
+            nofollow
+            noarchive
+            noimageindex
+            nosnippet
+          }
+          opengraphTitle
+          opengraphUrl
+          opengraphSiteName
+          opengraphType
+          opengraphAuthor
+          opengraphPublisher
+          opengraphPublishedTime
+          opengraphModifiedTime
+          opengraphDescription
+          opengraphImage { sourceUrl altText }
+          opengraphLocale
+          opengraphFbAppId
+          opengraphEnabled
+          twitterTitle
+          twitterDescription
+          twitterCardType
+          twitterImage { sourceUrl altText }
+          twitterCreator
+          twitterSite
+          canonical
+          breadcrumbs { url text }
+          cornerstone
+          fullHead
+          head { html json }
+          relNext
+          relPrev
+          breadcrumbTitle
+          objectPublishedAt
+          objectLastModified
+          language
+          region
+          readingTime
+          schema {
+            pageType
+            articleType
+            raw
+          }
+          analysis {
+            keywordScore
+            readabilityScore
+            inclusiveLanguageScore
+            linkCount
+            incomingLinkCount
+          }
+        }
+      }
+    }
+  }
+
+  # ─── TAXONOMY SEO ───
+  categories(first: 1) {
+    nodes {
+      name
+      seo {
+        title
+        metaDesc
+        focuskw
+        metaKeywords
+        metaRobotsNoindex
+        metaRobotsNofollow
+        robots {
+          noindex
+          nofollow
+          noarchive
+          noimageindex
+          nosnippet
+        }
+        opengraphTitle
+        opengraphUrl
+        opengraphSiteName
+        opengraphType
+        opengraphAuthor
+        opengraphPublisher
+        opengraphPublishedTime
+        opengraphModifiedTime
+        opengraphDescription
+        opengraphImage { sourceUrl altText }
+        opengraphLocale
+        opengraphFbAppId
+        opengraphEnabled
+        twitterTitle
+        twitterDescription
+        twitterCardType
+        twitterImage { sourceUrl altText }
+        twitterCreator
+        twitterSite
+        canonical
+        breadcrumbs { url text }
+        cornerstone
+        fullHead
+        head { html json }
+        relNext
+        relPrev
+        breadcrumbTitle
+        objectPublishedAt
+        objectLastModified
+        language
+        region
+        schema { raw }
+        analysis {
+          keywordScore
+          readabilityScore
+          inclusiveLanguageScore
+          linkCount
+          incomingLinkCount
+        }
+      }
+    }
+  }
+
+  # ─── USER SEO ───
+  users(first: 1) {
+    nodes {
+      name
+      seo {
+        title
+        metaDesc
+        metaRobotsNoindex
+        metaRobotsNofollow
+        robots {
+          noindex
+          nofollow
+          noarchive
+          noimageindex
+          nosnippet
+        }
+        canonical
+        opengraphTitle
+        opengraphDescription
+        opengraphImage { sourceUrl altText }
+        opengraphLocale
+        opengraphFbAppId
+        opengraphEnabled
+        twitterImage { sourceUrl altText }
+        twitterTitle
+        twitterDescription
+        twitterCreator
+        twitterSite
+        language
+        region
+        breadcrumbTitle
+        fullHead
+        head { html json }
+        relNext
+        relPrev
+        social {
+          facebook
+          twitter
+          instagram
+          linkedIn
+          mySpace
+          pinterest
+          youTube
+          soundCloud
+          wikipedia
+          mastodon
+        }
+        schema {
+          raw
+          pageType
+          articleType
+        }
+        analysis {
+          keywordScore
+          readabilityScore
+          inclusiveLanguageScore
+          linkCount
+          incomingLinkCount
+        }
+      }
+    }
+  }
+
+  # ─── GLOBAL SEO CONFIG ───
+  seo {
+    meta {
+      homepage { title description }
+      author {
+        title
+        description
+        noindex
+        noindexNoPosts
+        social { title description image { sourceUrl } }
+      }
+      date {
+        title
+        description
+        noindex
+        social { title description image { sourceUrl } }
+      }
+      search { title }
+      config { separator }
+      notFound { title breadcrumb }
+    }
+
+    schema {
+      companyName
+      personName
+      companyOrPerson
+      companyLogo { sourceUrl }
+      personLogo { sourceUrl }
+      logo { sourceUrl }
+      siteName
+      wordpressSiteName
+      siteUrl
+      homeUrl
+      inLanguage
+    }
+
+    webmaster {
+      baiduVerify
+      googleVerify
+      msVerify
+      yandexVerify
+    }
+
+    social {
+      facebook { url defaultImage { sourceUrl } }
+      twitter { username cardType enabled }
+      instagram { url }
+      linkedIn { url }
+      mastodon { url }
+      mySpace { url }
+      pinterest { url metaTag }
+      youTube { url }
+      wikipedia { url }
+      otherSocials
+    }
+
+    breadcrumbs {
+      enabled
+      boldLast
+      showBlogPage
+      notFoundText
+      archivePrefix
+      homeText
+      prefix
+      searchPrefix
+      separator
+    }
+
+    redirects {
+      origin
+      target
+      type
+      format
+    }
+
+    openGraph {
+      defaultImage { sourceUrl }
+      frontPage {
+        title
+        description
+        image { sourceUrl }
+      }
+      enabled
+    }
+
+    contentTypes {
+      post {
+        title
+        metaDesc
+        metaRobotsNoindex
+        schemaType
+        articleType
+        schema { raw }
+        archive {
+          hasArchive
+          archiveLink
+          title
+          metaDesc
+          metaRobotsNoindex
+          metaRobotsNofollow
+          metaRobotsIndex
+          metaRobotsFollow
+          breadcrumbTitle
+          fullHead
+          head { html json }
+          social { title description image { sourceUrl } }
+        }
+      }
+      page {
+        title
+        metaDesc
+        metaRobotsNoindex
+        schemaType
+        articleType
+        schema { raw }
+        archive {
+          hasArchive
+          archiveLink
+          title
+          metaDesc
+          metaRobotsNoindex
+          metaRobotsNofollow
+          metaRobotsIndex
+          metaRobotsFollow
+          breadcrumbTitle
+          fullHead
+          head { html json }
+          social { title description image { sourceUrl } }
+        }
+      }
+    }
+
+    taxonomyArchives {
+      category {
+        archive {
+          title
+          metaDesc
+          metaRobotsNoindex
+          social { title description image { sourceUrl } }
+        }
+      }
+      tag {
+        archive {
+          title
+          metaDesc
+          metaRobotsNoindex
+          social { title description image { sourceUrl } }
+        }
+      }
+    }
+
+    advanced {
+      siteType
+      environmentType
+      hasMultipleAuthors
+      xmlSitemapEnabled
+      indexNowEnabled
+      indexNowKey
+      contentAnalysisActive
+      keywordAnalysisActive
+      inclusiveLanguageAnalysisActive
+    }
+  }
+}

--- a/includes/helpers/functions.php
+++ b/includes/helpers/functions.php
@@ -9,6 +9,8 @@ if (!defined('ABSPATH')) {
     exit();
 }
 
+use WPGraphQL\AppContext;
+
 /**
  * Format string for GraphQL.
  *
@@ -116,7 +118,7 @@ if (!function_exists('wpcom_vip_attachment_url_to_postid')) {
                     $cache_key,
                     'not_found',
                     'default',
-                    12 * HOUR_IN_SECONDS + mt_rand(0, 4 * HOUR_IN_SECONDS) // phpcs:ignore
+                    12 * HOUR_IN_SECONDS + mt_rand(0, 4 * HOUR_IN_SECONDS), // phpcs:ignore
                 );
                 $id = null; // Set $id to null instead of false
             } else {
@@ -124,7 +126,7 @@ if (!function_exists('wpcom_vip_attachment_url_to_postid')) {
                     $cache_key,
                     $id,
                     'default',
-                    24 * HOUR_IN_SECONDS + mt_rand(0, 12 * HOUR_IN_SECONDS) // phpcs:ignore
+                    24 * HOUR_IN_SECONDS + mt_rand(0, 12 * HOUR_IN_SECONDS), // phpcs:ignore
                 );
             }
         } elseif ('not_found' === $id) {
@@ -147,7 +149,7 @@ if (!function_exists('wpcom_vip_attachment_url_to_postid')) {
 function wp_gql_seo_attachment_url_to_postid($url)
 {
     $id = wpcom_vip_attachment_url_to_postid($url);
-    return (false === $id || empty($id)) ? null : $id;
+    return false === $id || empty($id) ? null : $id;
 }
 
 /**
@@ -189,28 +191,150 @@ function wp_gql_seo_build_taxonomy_types($taxonomies)
 /**
  * Get full head content from Yoast SEO.
  *
+ * Delegates to wp_gql_seo_get_head_obj to avoid calling get_head() twice
+ * when both fullHead and head are requested for the same meta object.
+ *
  * @param \Yoast\WP\SEO\Surfaces\Values\Meta|bool $metaForPost Meta object.
  * @return string
  */
 function wp_gql_seo_get_full_head($metaForPost)
 {
+    return wp_gql_seo_get_head_obj($metaForPost)['html'];
+}
+
+/**
+ * Get structured head (html + json) from Yoast SEO.
+ *
+ * @param \Yoast\WP\SEO\Surfaces\Values\Meta|bool $metaForPost Meta object.
+ * @return array
+ */
+function wp_gql_seo_get_head_obj($metaForPost)
+{
     if ($metaForPost !== false) {
         $head = $metaForPost->get_head();
+        $html = is_string($head) ? $head : $head->html;
+        $json = is_object($head) && isset($head->json) ? $head->json : [];
 
-        return is_string($head) ? $head : $head->html;
+        return [
+            'html' => $html,
+            'json' => wp_json_encode($json, JSON_UNESCAPED_SLASHES),
+        ];
     }
 
-    return '';
+    return [
+        'html' => '',
+        'json' => wp_json_encode([], JSON_UNESCAPED_SLASHES),
+    ];
+}
+
+/**
+ * Safely read a property from a Yoast Indexable (or any object/array).
+ *
+ * @param mixed  $indexable The indexable object (or null/false).
+ * @param string $key       The property key.
+ * @return mixed|null
+ */
+function wp_gql_seo_indexable_prop($indexable, $key)
+{
+    if (!is_object($indexable) || !isset($indexable->{$key})) {
+        return null;
+    }
+
+    return $indexable->{$key};
+}
+
+/**
+ * Build the SEOAnalysis data array from an Indexable.
+ *
+ * @param mixed $indexable The indexable object (or null/false).
+ * @return array
+ */
+function wp_gql_seo_build_analysis($indexable)
+{
+    if (!is_object($indexable)) {
+        return [
+            'keywordScore' => null,
+            'readabilityScore' => null,
+            'inclusiveLanguageScore' => null,
+            'linkCount' => null,
+            'incomingLinkCount' => null,
+        ];
+    }
+
+    return [
+        'keywordScore' => isset($indexable->primary_focus_keyword_score)
+            ? (int) $indexable->primary_focus_keyword_score
+            : null,
+        'readabilityScore' => isset($indexable->readability_score) ? (int) $indexable->readability_score : null,
+        'inclusiveLanguageScore' => isset($indexable->inclusive_language_score)
+            ? (int) $indexable->inclusive_language_score
+            : null,
+        'linkCount' => isset($indexable->link_count) ? (int) $indexable->link_count : null,
+        'incomingLinkCount' => isset($indexable->incoming_link_count) ? (int) $indexable->incoming_link_count : null,
+    ];
+}
+
+/**
+ * Build the SEORobots data array from Yoast robots array and Indexable.
+ *
+ * @param array $robots   The robots array from Meta (index/follow keys).
+ * @param mixed $indexable The indexable object (or null/false).
+ * @return array
+ */
+function wp_gql_seo_build_robots($robots, $indexable)
+{
+    return [
+        'noindex' => isset($robots['index']) ? wp_gql_seo_format_string($robots['index']) : null,
+        'nofollow' => isset($robots['follow']) ? wp_gql_seo_format_string($robots['follow']) : null,
+        'noarchive' => boolval(wp_gql_seo_indexable_prop($indexable, 'is_robots_noarchive')),
+        'noimageindex' => boolval(wp_gql_seo_indexable_prop($indexable, 'is_robots_noimageindex')),
+        'nosnippet' => boolval(wp_gql_seo_indexable_prop($indexable, 'is_robots_nosnippet')),
+    ];
+}
+
+/**
+ * Build the Premium social archive data from Yoast SEO Premium options.
+ *
+ * Returns null for title/description and null for image when the Premium
+ * option keys are absent (graceful free-tier fallback).
+ *
+ * @param string       $option_prefix The option prefix (e.g. 'ptarchive-post', 'tax-category', 'author-wpseo', 'archive-wpseo').
+ * @param array        $all           All Yoast SEO options.
+ * @param AppContext   $context       The GraphQL AppContext for deferred image loading.
+ * @return array
+ */
+function wp_gql_seo_get_premium_social($option_prefix, $all, $context)
+{
+    $title_key = 'social-title-' . $option_prefix;
+    $desc_key = 'social-description-' . $option_prefix;
+    $image_id_key = 'social-image-id-' . $option_prefix;
+
+    $has_premium = isset($all[$title_key]) || isset($all[$desc_key]) || isset($all[$image_id_key]);
+
+    if (!$has_premium) {
+        return [
+            'title' => null,
+            'description' => null,
+            'image' => null,
+        ];
+    }
+
+    return [
+        'title' => wp_gql_seo_format_string(wp_gql_seo_replace_vars($all[$title_key] ?? null)),
+        'description' => wp_gql_seo_format_string(wp_gql_seo_replace_vars($all[$desc_key] ?? null)),
+        'image' => $context->get_loader('post')->load_deferred(absint($all[$image_id_key] ?? 0)),
+    ];
 }
 
 /**
  * Build content type data for GraphQL schema.
  *
- * @param array $types Post types.
- * @param array $all All Yoast SEO options.
+ * @param array      $types   Post types.
+ * @param array      $all     All Yoast SEO options.
+ * @param AppContext $context The GraphQL AppContext for deferred image loading.
  * @return array
  */
-function wp_gql_seo_build_content_type_data($types, $all)
+function wp_gql_seo_build_content_type_data($types, $all, $context)
 {
     $carry = [];
 
@@ -236,27 +360,32 @@ function wp_gql_seo_build_content_type_data($types, $all)
             'metaDesc' => wp_gql_seo_format_string(wp_gql_seo_replace_vars($all['metadesc-' . $type] ?? null)),
             'metaRobotsNoindex' => boolval($all['noindex-' . $type] ?? false),
             'schemaType' => $all['schema-page-type-' . $type] ?? null,
+            'articleType' => $all['schema-article-type-' . $type] ?? null,
             'schema' => [
                 'raw' =>
-                    !empty($meta) && !empty($meta->schema) ? wp_json_encode($meta->schema, JSON_UNESCAPED_SLASHES) : null,
+                    !empty($meta) && !empty($meta->schema)
+                        ? wp_json_encode($meta->schema, JSON_UNESCAPED_SLASHES)
+                        : null,
             ],
             'archive' => [
                 'hasArchive' => boolval($post_type_object->has_archive),
                 'archiveLink' => apply_filters('wp_gql_seo_archive_link', get_post_type_archive_link($type), $type),
-                'title' => wp_gql_seo_format_string($meta->title ?? null),
+                'title' => wp_gql_seo_format_string($meta !== false ? $meta->title : null),
                 'metaDesc' => wp_gql_seo_format_string($all['metadesc-ptarchive-' . $type] ?? null),
                 'metaRobotsNoindex' =>
-                    !empty($meta) && !empty($meta->robots['index']) && $meta->robots['index'] === 'index'
+                    $meta !== false && !empty($meta->robots['index']) && $meta->robots['index'] === 'index'
                         ? false
                         : true,
                 'metaRobotsNofollow' =>
-                    !empty($meta) && !empty($meta->robots['follow']) && $meta->robots['follow'] === 'follow'
+                    $meta !== false && !empty($meta->robots['follow']) && $meta->robots['follow'] === 'follow'
                         ? false
                         : true,
-                'metaRobotsIndex' => $meta->robots['index'] ?? 'noindex',
-                'metaRobotsFollow' => $meta->robots['follow'] ?? 'nofollow',
+                'metaRobotsIndex' => $meta !== false ? ($meta->robots['index'] ?? 'noindex') : 'noindex',
+                'metaRobotsFollow' => $meta !== false ? ($meta->robots['follow'] ?? 'nofollow') : 'nofollow',
                 'breadcrumbTitle' => wp_gql_seo_format_string($all['bctitle-ptarchive-' . $type] ?? null),
                 'fullHead' => wp_gql_seo_get_full_head($meta),
+                'head' => wp_gql_seo_get_head_obj($meta),
+                'social' => wp_gql_seo_get_premium_social('ptarchive-' . $type, $all, $context),
             ],
         ];
     }
@@ -267,11 +396,12 @@ function wp_gql_seo_build_content_type_data($types, $all)
 /**
  * Build taxonomy data for GraphQL schema.
  *
- * @param array $taxonomies Taxonomies.
- * @param array $all All Yoast SEO options.
+ * @param array      $taxonomies Taxonomies.
+ * @param array      $all        All Yoast SEO options.
+ * @param AppContext $context    The GraphQL AppContext for deferred image loading.
  * @return array
  */
-function wp_gql_seo_build_taxonomy_data($taxonomies, $all)
+function wp_gql_seo_build_taxonomy_data($taxonomies, $all, $context)
 {
     $carry = [];
 
@@ -293,9 +423,10 @@ function wp_gql_seo_build_taxonomy_data($taxonomies, $all)
             'archive' => [
                 'title' => wp_gql_seo_format_string(wp_gql_seo_replace_vars($all['title-tax-' . $taxonomy] ?? null)),
                 'metaDesc' => wp_gql_seo_format_string(
-                    wp_gql_seo_replace_vars($all['metadesc-tax-' . $taxonomy] ?? null)
+                    wp_gql_seo_replace_vars($all['metadesc-tax-' . $taxonomy] ?? null),
                 ),
                 'metaRobotsNoindex' => boolval($all['noindex-tax-' . $taxonomy] ?? false),
+                'social' => wp_gql_seo_get_premium_social('tax-' . $taxonomy, $all, $context),
             ],
         ];
     }

--- a/includes/helpers/functions.php
+++ b/includes/helpers/functions.php
@@ -118,7 +118,7 @@ if (!function_exists('wpcom_vip_attachment_url_to_postid')) {
                     $cache_key,
                     'not_found',
                     'default',
-                    12 * HOUR_IN_SECONDS + mt_rand(0, 4 * HOUR_IN_SECONDS), // phpcs:ignore
+                    12 * HOUR_IN_SECONDS + mt_rand(0, 4 * HOUR_IN_SECONDS) // phpcs:ignore
                 );
                 $id = null; // Set $id to null instead of false
             } else {
@@ -126,7 +126,7 @@ if (!function_exists('wpcom_vip_attachment_url_to_postid')) {
                     $cache_key,
                     $id,
                     'default',
-                    24 * HOUR_IN_SECONDS + mt_rand(0, 12 * HOUR_IN_SECONDS), // phpcs:ignore
+                    24 * HOUR_IN_SECONDS + mt_rand(0, 12 * HOUR_IN_SECONDS) // phpcs:ignore
                 );
             }
         } elseif ('not_found' === $id) {
@@ -423,7 +423,7 @@ function wp_gql_seo_build_taxonomy_data($taxonomies, $all, $context)
             'archive' => [
                 'title' => wp_gql_seo_format_string(wp_gql_seo_replace_vars($all['title-tax-' . $taxonomy] ?? null)),
                 'metaDesc' => wp_gql_seo_format_string(
-                    wp_gql_seo_replace_vars($all['metadesc-tax-' . $taxonomy] ?? null),
+                    wp_gql_seo_replace_vars($all['metadesc-tax-' . $taxonomy] ?? null)
                 ),
                 'metaRobotsNoindex' => boolval($all['noindex-tax-' . $taxonomy] ?? false),
                 'social' => wp_gql_seo_get_premium_social('tax-' . $taxonomy, $all, $context),

--- a/includes/resolvers/post-type.php
+++ b/includes/resolvers/post-type.php
@@ -36,6 +36,7 @@ function wp_gql_seo_get_post_type_graphql_fields($post, array $args, AppContext 
 
     // https://developer.yoast.com/blog/yoast-seo-14-0-using-yoast-seo-surfaces/
     $robots = $meta !== false ? $meta->robots : [];
+    $indexable = $meta !== false ? $meta->indexable : null;
 
     // Get data
     $seo = [
@@ -45,6 +46,7 @@ function wp_gql_seo_get_post_type_graphql_fields($post, array $args, AppContext 
         'metaKeywords' => wp_gql_seo_format_string(get_post_meta($post->ID, '_yoast_wpseo_metakeywords', true)),
         'metaRobotsNoindex' => $robots['index'] ?? '',
         'metaRobotsNofollow' => $robots['follow'] ?? '',
+        'robots' => wp_gql_seo_build_robots($robots, $indexable),
         'opengraphTitle' => wp_gql_seo_format_string($meta !== false ? $meta->open_graph_title : ''),
         'opengraphUrl' => wp_gql_seo_format_string($meta !== false ? $meta->open_graph_url : ''),
         'opengraphSiteName' => wp_gql_seo_format_string($meta !== false ? $meta->open_graph_site_name : ''),
@@ -52,10 +54,10 @@ function wp_gql_seo_get_post_type_graphql_fields($post, array $args, AppContext 
         'opengraphAuthor' => wp_gql_seo_format_string($meta !== false ? $meta->open_graph_article_author : ''),
         'opengraphPublisher' => wp_gql_seo_format_string($meta !== false ? $meta->open_graph_article_publisher : ''),
         'opengraphPublishedTime' => wp_gql_seo_format_string(
-            $meta !== false ? $meta->open_graph_article_published_time : ''
+            $meta !== false ? $meta->open_graph_article_published_time : '',
         ),
         'opengraphModifiedTime' => wp_gql_seo_format_string(
-            $meta !== false ? $meta->open_graph_article_modified_time : ''
+            $meta !== false ? $meta->open_graph_article_modified_time : '',
         ),
         'opengraphDescription' => wp_gql_seo_format_string($meta !== false ? $meta->open_graph_description : ''),
         'opengraphImage' => function () use ($context, $meta) {
@@ -63,6 +65,9 @@ function wp_gql_seo_get_post_type_graphql_fields($post, array $args, AppContext 
 
             return $context->get_loader('post')->load_deferred(absint($id));
         },
+        'opengraphLocale' => wp_gql_seo_format_string($meta !== false ? $meta->open_graph_locale : ''),
+        'opengraphFbAppId' => wp_gql_seo_format_string($meta !== false ? $meta->open_graph_fb_app_id : ''),
+        'opengraphEnabled' => $meta !== false ? boolval($meta->open_graph_enabled) : null,
         'twitterCardType' => wp_gql_seo_format_string($meta !== false ? $meta->twitter_card : ''),
         'twitterTitle' => wp_gql_seo_format_string($meta !== false ? $meta->twitter_title : ''),
         'twitterDescription' => wp_gql_seo_format_string($meta !== false ? $meta->twitter_description : ''),
@@ -77,16 +82,27 @@ function wp_gql_seo_get_post_type_graphql_fields($post, array $args, AppContext 
 
             return $context->get_loader('post')->load_deferred(absint($id));
         },
+        'twitterCreator' => wp_gql_seo_format_string($meta !== false ? $meta->twitter_creator : ''),
+        'twitterSite' => wp_gql_seo_format_string($meta !== false ? $meta->twitter_site : ''),
         'canonical' => wp_gql_seo_format_string($meta !== false ? $meta->canonical : ''),
         'readingTime' => floatval($meta !== false ? $meta->estimated_reading_time_minutes : ''),
         'breadcrumbs' => $meta !== false ? $meta->breadcrumbs : [],
         'cornerstone' => boolval($meta !== false && $meta->indexable ? $meta->indexable->is_cornerstone : false),
         'fullHead' => wp_gql_seo_get_full_head($meta),
+        'head' => wp_gql_seo_get_head_obj($meta),
+        'relNext' => wp_gql_seo_format_string($meta !== false ? $meta->rel_next : ''),
+        'relPrev' => wp_gql_seo_format_string($meta !== false ? $meta->rel_prev : ''),
+        'breadcrumbTitle' => wp_gql_seo_format_string(wp_gql_seo_indexable_prop($indexable, 'breadcrumb_title')),
+        'objectPublishedAt' => wp_gql_seo_format_string(wp_gql_seo_indexable_prop($indexable, 'object_published_at')),
+        'objectLastModified' => wp_gql_seo_format_string(wp_gql_seo_indexable_prop($indexable, 'object_last_modified')),
+        'language' => wp_gql_seo_format_string(wp_gql_seo_indexable_prop($indexable, 'language')),
+        'region' => wp_gql_seo_format_string(wp_gql_seo_indexable_prop($indexable, 'region')),
         'schema' => [
             'pageType' => $meta !== false && is_array($meta->schema_page_type) ? $meta->schema_page_type : [],
             'articleType' => $meta !== false && is_array($meta->schema_article_type) ? $meta->schema_article_type : [],
             'raw' => wp_json_encode($schemaArray, JSON_UNESCAPED_SLASHES),
         ],
+        'analysis' => wp_gql_seo_build_analysis($indexable),
     ];
 
     return !empty($seo) ? $seo : null;

--- a/includes/resolvers/post-type.php
+++ b/includes/resolvers/post-type.php
@@ -54,10 +54,10 @@ function wp_gql_seo_get_post_type_graphql_fields($post, array $args, AppContext 
         'opengraphAuthor' => wp_gql_seo_format_string($meta !== false ? $meta->open_graph_article_author : ''),
         'opengraphPublisher' => wp_gql_seo_format_string($meta !== false ? $meta->open_graph_article_publisher : ''),
         'opengraphPublishedTime' => wp_gql_seo_format_string(
-            $meta !== false ? $meta->open_graph_article_published_time : '',
+            $meta !== false ? $meta->open_graph_article_published_time : ''
         ),
         'opengraphModifiedTime' => wp_gql_seo_format_string(
-            $meta !== false ? $meta->open_graph_article_modified_time : '',
+            $meta !== false ? $meta->open_graph_article_modified_time : ''
         ),
         'opengraphDescription' => wp_gql_seo_format_string($meta !== false ? $meta->open_graph_description : ''),
         'opengraphImage' => function () use ($context, $meta) {

--- a/includes/resolvers/root-query.php
+++ b/includes/resolvers/root-query.php
@@ -39,8 +39,8 @@ add_action('graphql_register_types', function () {
                 ];
             };
 
-            $contentTypes = wp_gql_seo_build_content_type_data($post_types, $all);
-            $taxonomyTypes = wp_gql_seo_build_taxonomy_data($taxonomies, $all);
+            $contentTypes = wp_gql_seo_build_content_type_data($post_types, $all, $context);
+            $taxonomyTypes = wp_gql_seo_build_taxonomy_data($taxonomies, $all, $context);
 
             $homepage = [
                 'title' => wp_gql_seo_format_string(wp_gql_seo_replace_vars($all['title-home-wpseo'] ?? null)),
@@ -48,11 +48,23 @@ add_action('graphql_register_types', function () {
             ];
             $author = [
                 'title' => wp_gql_seo_format_string(wp_gql_seo_replace_vars($all['title-author-wpseo'] ?? null)),
-                'description' => wp_gql_seo_format_string(wp_gql_seo_replace_vars($all['metadesc-author-wpseo'] ?? null)),
+                'description' => wp_gql_seo_format_string(
+                    wp_gql_seo_replace_vars($all['metadesc-author-wpseo'] ?? null),
+                ),
+                'noindex' => boolval($all['noindex-author-wpseo'] ?? false),
+                'noindexNoPosts' => boolval($all['noindex-author-noposts-wpseo'] ?? false),
+                'social' => wp_gql_seo_get_premium_social('author-wpseo', $all, $context),
             ];
             $date = [
                 'title' => wp_gql_seo_format_string(wp_gql_seo_replace_vars($all['title-archive-wpseo'] ?? null)),
-                'description' => wp_gql_seo_format_string(wp_gql_seo_replace_vars($all['metadesc-archive-wpseo'] ?? null)),
+                'description' => wp_gql_seo_format_string(
+                    wp_gql_seo_replace_vars($all['metadesc-archive-wpseo'] ?? null),
+                ),
+                'noindex' => boolval($all['noindex-archive-wpseo'] ?? false),
+                'social' => wp_gql_seo_get_premium_social('archive-wpseo', $all, $context),
+            ];
+            $search = [
+                'title' => wp_gql_seo_format_string(wp_gql_seo_replace_vars($all['title-search-wpseo'] ?? null)),
             ];
             $config = [
                 'separator' => wp_gql_seo_format_string($all['separator'] ?? null),
@@ -69,6 +81,7 @@ add_action('graphql_register_types', function () {
                     'homepage' => $homepage,
                     'author' => $author,
                     'date' => $date,
+                    'search' => $search,
                     'config' => $config,
                     'notFound' => $notFound,
                 ],
@@ -81,17 +94,23 @@ add_action('graphql_register_types', function () {
                 'social' => [
                     'facebook' => [
                         'url' => wp_gql_seo_format_string($all['facebook_site'] ?? null),
-                        'defaultImage' => $context->get_loader('post')->load_deferred(absint($all['og_default_image_id'] ?? 0)),
+                        'defaultImage' => $context
+                            ->get_loader('post')
+                            ->load_deferred(absint($all['og_default_image_id'] ?? 0)),
                     ],
                     'twitter' => [
                         'username' => wp_gql_seo_format_string($all['twitter_site'] ?? null),
                         'cardType' => wp_gql_seo_format_string($all['twitter_card_type'] ?? null),
+                        'enabled' => boolval($all['twitter'] ?? false),
                     ],
                     'instagram' => [
                         'url' => wp_gql_seo_format_string($all['instagram_url'] ?? null),
                     ],
                     'linkedIn' => [
                         'url' => wp_gql_seo_format_string($all['linkedin_url'] ?? null),
+                    ],
+                    'mastodon' => [
+                        'url' => wp_gql_seo_format_string($all['mastodon_url'] ?? null),
                     ],
                     'mySpace' => [
                         'url' => wp_gql_seo_format_string($all['myspace_url'] ?? null),
@@ -129,7 +148,7 @@ add_action('graphql_register_types', function () {
                         ->load_deferred(
                             $all['company_or_person'] === 'company'
                                 ? absint($all['company_logo_id'] ?? 0)
-                                : absint($all['person_logo_id'] ?? 0)
+                                : absint($all['person_logo_id'] ?? 0),
                         ),
                     'companyOrPerson' => wp_gql_seo_format_string($all['company_or_person'] ?? null),
                     'siteName' => wp_gql_seo_format_string(YoastSEO()->helpers->site->get_site_name()),
@@ -140,18 +159,34 @@ add_action('graphql_register_types', function () {
                 ],
                 'redirects' => array_map($mappedRedirects, $redirects),
                 'openGraph' => [
-                    'defaultImage' => $context->get_loader('post')->load_deferred(absint($all['og_default_image_id'] ?? 0)),
+                    'defaultImage' => $context
+                        ->get_loader('post')
+                        ->load_deferred(absint($all['og_default_image_id'] ?? 0)),
                     'frontPage' => [
                         'title' => wp_gql_seo_format_string(
-                            wp_gql_seo_replace_vars($all['open_graph_frontpage_title'] ?? null)
+                            wp_gql_seo_replace_vars($all['open_graph_frontpage_title'] ?? null),
                         ),
                         'description' => wp_gql_seo_format_string(
-                            wp_gql_seo_replace_vars($all['open_graph_frontpage_desc'] ?? null)
+                            wp_gql_seo_replace_vars($all['open_graph_frontpage_desc'] ?? null),
                         ),
                         'image' => $context
                             ->get_loader('post')
                             ->load_deferred(absint($all['open_graph_frontpage_image_id'] ?? 0)),
                     ],
+                    'enabled' => boolval($all['opengraph'] ?? false),
+                ],
+                'advanced' => [
+                    'siteType' => wp_gql_seo_format_string($all['site_type'] ?? null),
+                    'environmentType' => wp_gql_seo_format_string($all['environment_type'] ?? null),
+                    'hasMultipleAuthors' => isset($all['has_multiple_authors'])
+                        ? boolval($all['has_multiple_authors'])
+                        : null,
+                    'xmlSitemapEnabled' => boolval($all['enable_xml_sitemap'] ?? false),
+                    'indexNowEnabled' => boolval($all['enable_index_now'] ?? false),
+                    'indexNowKey' => wp_gql_seo_format_string($all['index_now_key'] ?? null),
+                    'contentAnalysisActive' => boolval($all['content_analysis_active'] ?? false),
+                    'keywordAnalysisActive' => boolval($all['keyword_analysis_active'] ?? false),
+                    'inclusiveLanguageAnalysisActive' => boolval($all['inclusive_language_analysis_active'] ?? false),
                 ],
             ];
         },
@@ -172,7 +207,7 @@ add_action('graphql_register_types', function () {
                     'description' => sprintf(
                         // translators: %s is the post type singular name.
                         __('Raw schema for %s', 'wp-graphql-yoast-seo'),
-                        $post_type_object->graphql_single_name
+                        $post_type_object->graphql_single_name,
                     ),
                     'resolve' => function () use ($post_type) {
                         $meta = YoastSEO()->meta->for_post_type_archive($post_type);

--- a/includes/resolvers/root-query.php
+++ b/includes/resolvers/root-query.php
@@ -49,7 +49,7 @@ add_action('graphql_register_types', function () {
             $author = [
                 'title' => wp_gql_seo_format_string(wp_gql_seo_replace_vars($all['title-author-wpseo'] ?? null)),
                 'description' => wp_gql_seo_format_string(
-                    wp_gql_seo_replace_vars($all['metadesc-author-wpseo'] ?? null),
+                    wp_gql_seo_replace_vars($all['metadesc-author-wpseo'] ?? null)
                 ),
                 'noindex' => boolval($all['noindex-author-wpseo'] ?? false),
                 'noindexNoPosts' => boolval($all['noindex-author-noposts-wpseo'] ?? false),
@@ -58,7 +58,7 @@ add_action('graphql_register_types', function () {
             $date = [
                 'title' => wp_gql_seo_format_string(wp_gql_seo_replace_vars($all['title-archive-wpseo'] ?? null)),
                 'description' => wp_gql_seo_format_string(
-                    wp_gql_seo_replace_vars($all['metadesc-archive-wpseo'] ?? null),
+                    wp_gql_seo_replace_vars($all['metadesc-archive-wpseo'] ?? null)
                 ),
                 'noindex' => boolval($all['noindex-archive-wpseo'] ?? false),
                 'social' => wp_gql_seo_get_premium_social('archive-wpseo', $all, $context),
@@ -148,7 +148,7 @@ add_action('graphql_register_types', function () {
                         ->load_deferred(
                             $all['company_or_person'] === 'company'
                                 ? absint($all['company_logo_id'] ?? 0)
-                                : absint($all['person_logo_id'] ?? 0),
+                                : absint($all['person_logo_id'] ?? 0)
                         ),
                     'companyOrPerson' => wp_gql_seo_format_string($all['company_or_person'] ?? null),
                     'siteName' => wp_gql_seo_format_string(YoastSEO()->helpers->site->get_site_name()),
@@ -164,10 +164,10 @@ add_action('graphql_register_types', function () {
                         ->load_deferred(absint($all['og_default_image_id'] ?? 0)),
                     'frontPage' => [
                         'title' => wp_gql_seo_format_string(
-                            wp_gql_seo_replace_vars($all['open_graph_frontpage_title'] ?? null),
+                            wp_gql_seo_replace_vars($all['open_graph_frontpage_title'] ?? null)
                         ),
                         'description' => wp_gql_seo_format_string(
-                            wp_gql_seo_replace_vars($all['open_graph_frontpage_desc'] ?? null),
+                            wp_gql_seo_replace_vars($all['open_graph_frontpage_desc'] ?? null)
                         ),
                         'image' => $context
                             ->get_loader('post')
@@ -207,7 +207,7 @@ add_action('graphql_register_types', function () {
                     'description' => sprintf(
                         // translators: %s is the post type singular name.
                         __('Raw schema for %s', 'wp-graphql-yoast-seo'),
-                        $post_type_object->graphql_single_name,
+                        $post_type_object->graphql_single_name
                     ),
                     'resolve' => function () use ($post_type) {
                         $meta = YoastSEO()->meta->for_post_type_archive($post_type);

--- a/includes/resolvers/taxonomy.php
+++ b/includes/resolvers/taxonomy.php
@@ -31,22 +31,26 @@ add_action('graphql_register_types', function () {
                 'description' => sprintf(
                     // translators: %s is the taxonomy label.
                     __('The Yoast SEO data of the %s taxonomy.', 'wp-graphql-yoast-seo'),
-                    $taxonomy->label
+                    $taxonomy->label,
                 ),
                 'resolve' => function ($term, array $args, AppContext $context) {
                     $term_obj = get_term($term->term_id);
 
                     $meta = WPSEO_Taxonomy_Meta::get_term_meta((int) $term_obj->term_id, $term_obj->taxonomy);
                     $yoast_meta = YoastSEO()->meta->for_term($term->term_id);
+
+                    if ($yoast_meta === false) {
+                        return null;
+                    }
+
                     $robots = $yoast_meta->robots;
 
                     $schemaArray = $yoast_meta->schema;
+                    $indexable = $yoast_meta->indexable;
 
                     // Get data
                     $seo = [
-                        'title' => wp_gql_seo_format_string(
-                            html_entity_decode(wp_strip_all_tags($yoast_meta->title))
-                        ),
+                        'title' => wp_gql_seo_format_string(html_entity_decode(wp_strip_all_tags($yoast_meta->title))),
                         'metaDesc' => wp_gql_seo_format_string($yoast_meta->description),
                         'focuskw' => isset($meta['wpseo_focuskw'])
                             ? wp_gql_seo_format_string($meta['wpseo_focuskw'])
@@ -56,57 +60,58 @@ add_action('graphql_register_types', function () {
                             : null,
                         'metaRobotsNoindex' => $robots['index'],
                         'metaRobotsNofollow' => $robots['follow'],
-                        'opengraphTitle' => wp_gql_seo_format_string(
-                            $yoast_meta->open_graph_title
-                        ),
-                        'opengraphUrl' => wp_gql_seo_format_string(
-                            $yoast_meta->open_graph_url
-                        ),
-                        'opengraphSiteName' => wp_gql_seo_format_string(
-                            $yoast_meta->open_graph_site_name
-                        ),
-                        'opengraphType' => wp_gql_seo_format_string(
-                            $yoast_meta->open_graph_type
-                        ),
-                        'opengraphAuthor' => wp_gql_seo_format_string(
-                            $yoast_meta->open_graph_article_author
-                        ),
-                        'opengraphPublisher' => wp_gql_seo_format_string(
-                            $yoast_meta->open_graph_article_publisher
-                        ),
+                        'robots' => wp_gql_seo_build_robots($robots, $indexable),
+                        'opengraphTitle' => wp_gql_seo_format_string($yoast_meta->open_graph_title),
+                        'opengraphUrl' => wp_gql_seo_format_string($yoast_meta->open_graph_url),
+                        'opengraphSiteName' => wp_gql_seo_format_string($yoast_meta->open_graph_site_name),
+                        'opengraphType' => wp_gql_seo_format_string($yoast_meta->open_graph_type),
+                        'opengraphAuthor' => wp_gql_seo_format_string($yoast_meta->open_graph_article_author),
+                        'opengraphPublisher' => wp_gql_seo_format_string($yoast_meta->open_graph_article_publisher),
                         'opengraphPublishedTime' => wp_gql_seo_format_string(
-                            $yoast_meta->open_graph_article_published_time
+                            $yoast_meta->open_graph_article_published_time,
                         ),
                         'opengraphModifiedTime' => wp_gql_seo_format_string(
-                            $yoast_meta->open_graph_article_modified_time
+                            $yoast_meta->open_graph_article_modified_time,
                         ),
-                        'opengraphDescription' => wp_gql_seo_format_string(
-                            YoastSEO()->meta->for_term($term->term_id)->open_graph_description
-                        ),
+                        'opengraphDescription' => wp_gql_seo_format_string($yoast_meta->open_graph_description),
                         'opengraphImage' => $context
                             ->get_loader('post')
                             ->load_deferred(absint($meta['wpseo_opengraph-image-id'] ?? 0)),
-                        'twitterCardType' => wp_gql_seo_format_string(
-                            YoastSEO()->meta->for_term($term->term_id)->twitter_card
-                        ),
-                        'twitterTitle' => wp_gql_seo_format_string(
-                            YoastSEO()->meta->for_term($term->term_id)->twitter_title
-                        ),
-                        'twitterDescription' => wp_gql_seo_format_string(
-                            YoastSEO()->meta->for_term($term->term_id)->twitter_description
-                        ),
+                        'opengraphLocale' => wp_gql_seo_format_string($yoast_meta->open_graph_locale),
+                        'opengraphFbAppId' => wp_gql_seo_format_string($yoast_meta->open_graph_fb_app_id),
+                        'opengraphEnabled' => boolval($yoast_meta->open_graph_enabled),
+                        'twitterCardType' => wp_gql_seo_format_string($yoast_meta->twitter_card),
+                        'twitterTitle' => wp_gql_seo_format_string($yoast_meta->twitter_title),
+                        'twitterDescription' => wp_gql_seo_format_string($yoast_meta->twitter_description),
                         'twitterImage' => $context
                             ->get_loader('post')
                             ->load_deferred(absint($meta['wpseo_twitter-image-id'] ?? 0)),
-                        'canonical' => isset(YoastSEO()->meta->for_term($term->term_id)->canonical)
-                            ? wp_gql_seo_format_string(YoastSEO()->meta->for_term($term->term_id)->canonical)
+                        'twitterCreator' => wp_gql_seo_format_string($yoast_meta->twitter_creator),
+                        'twitterSite' => wp_gql_seo_format_string($yoast_meta->twitter_site),
+                        'canonical' => isset($yoast_meta->canonical)
+                            ? wp_gql_seo_format_string($yoast_meta->canonical)
                             : null,
-                        'breadcrumbs' => YoastSEO()->meta->for_term($term->term_id)->breadcrumbs,
-                        'cornerstone' => boolval(YoastSEO()->meta->for_term($term->term_id)->is_cornerstone),
-                        'fullHead' => wp_gql_seo_get_full_head(YoastSEO()->meta->for_term($term->term_id)),
+                        'breadcrumbs' => $yoast_meta->breadcrumbs,
+                        'cornerstone' => boolval($yoast_meta->is_cornerstone),
+                        'fullHead' => wp_gql_seo_get_full_head($yoast_meta),
+                        'head' => wp_gql_seo_get_head_obj($yoast_meta),
+                        'relNext' => wp_gql_seo_format_string($yoast_meta->rel_next),
+                        'relPrev' => wp_gql_seo_format_string($yoast_meta->rel_prev),
+                        'breadcrumbTitle' => wp_gql_seo_format_string(
+                            wp_gql_seo_indexable_prop($indexable, 'breadcrumb_title'),
+                        ),
+                        'objectPublishedAt' => wp_gql_seo_format_string(
+                            wp_gql_seo_indexable_prop($indexable, 'object_published_at'),
+                        ),
+                        'objectLastModified' => wp_gql_seo_format_string(
+                            wp_gql_seo_indexable_prop($indexable, 'object_last_modified'),
+                        ),
+                        'language' => wp_gql_seo_format_string(wp_gql_seo_indexable_prop($indexable, 'language')),
+                        'region' => wp_gql_seo_format_string(wp_gql_seo_indexable_prop($indexable, 'region')),
                         'schema' => [
                             'raw' => wp_json_encode($schemaArray, JSON_UNESCAPED_SLASHES),
                         ],
+                        'analysis' => wp_gql_seo_build_analysis($indexable),
                     ];
 
                     wp_reset_postdata();
@@ -140,7 +145,7 @@ add_action('graphql_register_types', function () {
                         'description' => sprintf(
                             // translators: %s is the taxonomy name.
                             __('The Yoast SEO Primary %s', 'wp-graphql-yoast-seo'),
-                            $tax->name
+                            $tax->name,
                         ),
                         'resolve' => function ($item) use ($tax) {
                             $postId = $item['source']->ID;

--- a/includes/resolvers/taxonomy.php
+++ b/includes/resolvers/taxonomy.php
@@ -31,7 +31,7 @@ add_action('graphql_register_types', function () {
                 'description' => sprintf(
                     // translators: %s is the taxonomy label.
                     __('The Yoast SEO data of the %s taxonomy.', 'wp-graphql-yoast-seo'),
-                    $taxonomy->label,
+                    $taxonomy->label
                 ),
                 'resolve' => function ($term, array $args, AppContext $context) {
                     $term_obj = get_term($term->term_id);
@@ -68,10 +68,10 @@ add_action('graphql_register_types', function () {
                         'opengraphAuthor' => wp_gql_seo_format_string($yoast_meta->open_graph_article_author),
                         'opengraphPublisher' => wp_gql_seo_format_string($yoast_meta->open_graph_article_publisher),
                         'opengraphPublishedTime' => wp_gql_seo_format_string(
-                            $yoast_meta->open_graph_article_published_time,
+                            $yoast_meta->open_graph_article_published_time
                         ),
                         'opengraphModifiedTime' => wp_gql_seo_format_string(
-                            $yoast_meta->open_graph_article_modified_time,
+                            $yoast_meta->open_graph_article_modified_time
                         ),
                         'opengraphDescription' => wp_gql_seo_format_string($yoast_meta->open_graph_description),
                         'opengraphImage' => $context
@@ -98,13 +98,13 @@ add_action('graphql_register_types', function () {
                         'relNext' => wp_gql_seo_format_string($yoast_meta->rel_next),
                         'relPrev' => wp_gql_seo_format_string($yoast_meta->rel_prev),
                         'breadcrumbTitle' => wp_gql_seo_format_string(
-                            wp_gql_seo_indexable_prop($indexable, 'breadcrumb_title'),
+                            wp_gql_seo_indexable_prop($indexable, 'breadcrumb_title')
                         ),
                         'objectPublishedAt' => wp_gql_seo_format_string(
-                            wp_gql_seo_indexable_prop($indexable, 'object_published_at'),
+                            wp_gql_seo_indexable_prop($indexable, 'object_published_at')
                         ),
                         'objectLastModified' => wp_gql_seo_format_string(
-                            wp_gql_seo_indexable_prop($indexable, 'object_last_modified'),
+                            wp_gql_seo_indexable_prop($indexable, 'object_last_modified')
                         ),
                         'language' => wp_gql_seo_format_string(wp_gql_seo_indexable_prop($indexable, 'language')),
                         'region' => wp_gql_seo_format_string(wp_gql_seo_indexable_prop($indexable, 'region')),
@@ -145,7 +145,7 @@ add_action('graphql_register_types', function () {
                         'description' => sprintf(
                             // translators: %s is the taxonomy name.
                             __('The Yoast SEO Primary %s', 'wp-graphql-yoast-seo'),
-                            $tax->name,
+                            $tax->name
                         ),
                         'resolve' => function ($item) use ($tax) {
                             $postId = $item['source']->ID;

--- a/includes/resolvers/user.php
+++ b/includes/resolvers/user.php
@@ -28,6 +28,7 @@ add_action('graphql_register_types', function () {
             }
 
             $robots = $authorMeta->robots;
+            $indexable = $authorMeta->indexable;
 
             $schemaArray = $authorMeta->schema;
 
@@ -36,21 +37,28 @@ add_action('graphql_register_types', function () {
                 'metaDesc' => wp_gql_seo_format_string($authorMeta->description),
                 'metaRobotsNoindex' => $robots['index'],
                 'metaRobotsNofollow' => $robots['follow'],
-                'canonical' => $authorMeta->canonical,
-                'opengraphTitle' => $authorMeta->open_graph_title,
-                'opengraphDescription' => $authorMeta->open_graph_description,
+                'robots' => wp_gql_seo_build_robots($robots, $indexable),
+                'canonical' => wp_gql_seo_format_string($authorMeta->canonical),
+                'opengraphTitle' => wp_gql_seo_format_string($authorMeta->open_graph_title),
+                'opengraphDescription' => wp_gql_seo_format_string($authorMeta->open_graph_description),
                 'opengraphImage' => $context
                     ->get_loader('post')
                     ->load_deferred(absint($authorMeta->open_graph_image_id)),
-                'twitterImage' => $context
-                    ->get_loader('post')
-                    ->load_deferred(absint($authorMeta->twitter_image_id)),
-                'twitterTitle' => $authorMeta->twitter_title,
-                'twitterDescription' => $authorMeta->twitter_description,
-                'language' => $authorMeta->language,
-                'region' => $authorMeta->region,
-                'breadcrumbTitle' => $authorMeta->breadcrumb_title,
+                'opengraphLocale' => wp_gql_seo_format_string($authorMeta->open_graph_locale),
+                'opengraphFbAppId' => wp_gql_seo_format_string($authorMeta->open_graph_fb_app_id),
+                'opengraphEnabled' => boolval($authorMeta->open_graph_enabled),
+                'twitterImage' => $context->get_loader('post')->load_deferred(absint($authorMeta->twitter_image_id)),
+                'twitterTitle' => wp_gql_seo_format_string($authorMeta->twitter_title),
+                'twitterDescription' => wp_gql_seo_format_string($authorMeta->twitter_description),
+                'twitterCreator' => wp_gql_seo_format_string($authorMeta->twitter_creator),
+                'twitterSite' => wp_gql_seo_format_string($authorMeta->twitter_site),
+                'language' => wp_gql_seo_format_string($authorMeta->language),
+                'region' => wp_gql_seo_format_string($authorMeta->region),
+                'breadcrumbTitle' => wp_gql_seo_format_string($authorMeta->breadcrumb_title),
                 'fullHead' => wp_gql_seo_get_full_head($authorMeta),
+                'head' => wp_gql_seo_get_head_obj($authorMeta),
+                'relNext' => wp_gql_seo_format_string($authorMeta->rel_next),
+                'relPrev' => wp_gql_seo_format_string($authorMeta->rel_prev),
                 'social' => [
                     'facebook' => wp_gql_seo_format_string(get_the_author_meta('facebook', $user->userId)),
                     'twitter' => wp_gql_seo_format_string(get_the_author_meta('twitter', $user->userId)),
@@ -61,17 +69,15 @@ add_action('graphql_register_types', function () {
                     'youTube' => wp_gql_seo_format_string(get_the_author_meta('youtube', $user->userId)),
                     'soundCloud' => wp_gql_seo_format_string(get_the_author_meta('soundcloud', $user->userId)),
                     'wikipedia' => wp_gql_seo_format_string(get_the_author_meta('wikipedia', $user->userId)),
+                    'mastodon' => wp_gql_seo_format_string(get_the_author_meta('mastodon', $user->userId)),
                 ],
 
                 'schema' => [
                     'raw' => wp_json_encode($schemaArray, JSON_UNESCAPED_SLASHES),
-                    'pageType' => is_array($authorMeta->schema_page_type)
-                        ? $authorMeta->schema_page_type
-                        : [],
-                    'articleType' => is_array($authorMeta->schema_article_type)
-                        ? $authorMeta->schema_article_type
-                        : [],
+                    'pageType' => is_array($authorMeta->schema_page_type) ? $authorMeta->schema_page_type : [],
+                    'articleType' => is_array($authorMeta->schema_article_type) ? $authorMeta->schema_article_type : [],
                 ],
+                'analysis' => wp_gql_seo_build_analysis($indexable),
             ];
 
             return !empty($userSeo) ? $userSeo : [];

--- a/includes/schema/types.php
+++ b/includes/schema/types.php
@@ -56,6 +56,7 @@ add_action('graphql_register_types', function () {
         'metaKeywords' => ['type' => 'String'],
         'metaRobotsNoindex' => ['type' => 'String'],
         'metaRobotsNofollow' => ['type' => 'String'],
+        'robots' => ['type' => 'SEORobots'],
         'opengraphTitle' => ['type' => 'String'],
         'opengraphUrl' => ['type' => 'String'],
         'opengraphSiteName' => ['type' => 'String'],
@@ -66,19 +67,33 @@ add_action('graphql_register_types', function () {
         'opengraphModifiedTime' => ['type' => 'String'],
         'opengraphDescription' => ['type' => 'String'],
         'opengraphImage' => ['type' => 'MediaItem'],
+        'opengraphLocale' => ['type' => 'String'],
+        'opengraphFbAppId' => ['type' => 'String'],
+        'opengraphEnabled' => ['type' => 'Boolean'],
         'twitterTitle' => ['type' => 'String'],
         'twitterDescription' => ['type' => 'String'],
         'twitterCardType' => ['type' => 'String'],
         'twitterImage' => ['type' => 'MediaItem'],
+        'twitterCreator' => ['type' => 'String'],
+        'twitterSite' => ['type' => 'String'],
         'canonical' => ['type' => 'String'],
         'breadcrumbs' => ['type' => ['list_of' => 'SEOPostTypeBreadcrumbs']],
         'cornerstone' => ['type' => 'Boolean'],
         'fullHead' => ['type' => 'String'],
+        'head' => ['type' => 'SEOHead'],
+        'relNext' => ['type' => 'String'],
+        'relPrev' => ['type' => 'String'],
+        'breadcrumbTitle' => ['type' => 'String'],
+        'objectPublishedAt' => ['type' => 'String'],
+        'objectLastModified' => ['type' => 'String'],
+        'language' => ['type' => 'String'],
+        'region' => ['type' => 'String'],
     ];
 
     register_graphql_object_type('TaxonomySEO', [
         'fields' => array_merge($baseSEOFields, [
             'schema' => ['type' => 'SEOTaxonomySchema'],
+            'analysis' => ['type' => 'SEOAnalysis'],
         ]),
     ]);
 
@@ -86,6 +101,7 @@ add_action('graphql_register_types', function () {
         'fields' => array_merge($baseSEOFields, [
             'readingTime' => ['type' => 'Float'],
             'schema' => ['type' => 'SEOPostTypeSchema'],
+            'analysis' => ['type' => 'SEOAnalysis'],
         ]),
     ]);
 
@@ -93,6 +109,36 @@ add_action('graphql_register_types', function () {
         'fields' => [
             'url' => ['type' => 'String'],
             'text' => ['type' => 'String'],
+        ],
+    ]);
+
+    register_graphql_object_type('SEORobots', [
+        'description' => __('The Yoast SEO robots directives', 'wp-graphql-yoast-seo'),
+        'fields' => [
+            'noindex' => ['type' => 'String'],
+            'nofollow' => ['type' => 'String'],
+            'noarchive' => ['type' => 'Boolean'],
+            'noimageindex' => ['type' => 'Boolean'],
+            'nosnippet' => ['type' => 'Boolean'],
+        ],
+    ]);
+
+    register_graphql_object_type('SEOAnalysis', [
+        'description' => __('The Yoast SEO analysis scores and link counts', 'wp-graphql-yoast-seo'),
+        'fields' => [
+            'keywordScore' => ['type' => 'Int'],
+            'readabilityScore' => ['type' => 'Int'],
+            'inclusiveLanguageScore' => ['type' => 'Int'],
+            'linkCount' => ['type' => 'Int'],
+            'incomingLinkCount' => ['type' => 'Int'],
+        ],
+    ]);
+
+    register_graphql_object_type('SEOHead', [
+        'description' => __('The Yoast SEO head output as structured HTML and JSON', 'wp-graphql-yoast-seo'),
+        'fields' => [
+            'html' => ['type' => 'String'],
+            'json' => ['type' => 'String'],
         ],
     ]);
 
@@ -108,6 +154,9 @@ add_action('graphql_register_types', function () {
         'fields' => [
             'title' => ['type' => 'String'],
             'description' => ['type' => 'String'],
+            'noindex' => ['type' => 'Boolean'],
+            'noindexNoPosts' => ['type' => 'Boolean'],
+            'social' => ['type' => 'SEOSocialArchive'],
         ],
     ]);
     register_graphql_object_type('SEOGlobalMetaDate', [
@@ -115,6 +164,14 @@ add_action('graphql_register_types', function () {
         'fields' => [
             'title' => ['type' => 'String'],
             'description' => ['type' => 'String'],
+            'noindex' => ['type' => 'Boolean'],
+            'social' => ['type' => 'SEOSocialArchive'],
+        ],
+    ]);
+    register_graphql_object_type('SEOGlobalMetaSearch', [
+        'description' => __('The Yoast SEO search results data', 'wp-graphql-yoast-seo'),
+        'fields' => [
+            'title' => ['type' => 'String'],
         ],
     ]);
     register_graphql_object_type('SEOGlobalMetaConfig', [
@@ -136,6 +193,7 @@ add_action('graphql_register_types', function () {
             'homepage' => ['type' => 'SEOGlobalMetaHome'],
             'author' => ['type' => 'SEOGlobalMetaAuthor'],
             'date' => ['type' => 'SEOGlobalMetaDate'],
+            'search' => ['type' => 'SEOGlobalMetaSearch'],
             'config' => ['type' => 'SEOGlobalMetaConfig'],
             'notFound' => ['type' => 'SEOGlobalMeta404'],
         ],
@@ -194,6 +252,7 @@ add_action('graphql_register_types', function () {
         'fields' => [
             'username' => ['type' => 'String'],
             'cardType' => ['type' => 'SEOCardType'],
+            'enabled' => ['type' => 'Boolean'],
         ],
     ]);
 
@@ -203,6 +262,11 @@ add_action('graphql_register_types', function () {
         ],
     ]);
     register_graphql_object_type('SEOSocialLinkedIn', [
+        'fields' => [
+            'url' => ['type' => 'String'],
+        ],
+    ]);
+    register_graphql_object_type('SEOSocialMastodon', [
         'fields' => [
             'url' => ['type' => 'String'],
         ],
@@ -238,6 +302,7 @@ add_action('graphql_register_types', function () {
             'twitter' => ['type' => 'SEOSocialTwitter'],
             'instagram' => ['type' => 'SEOSocialInstagram'],
             'linkedIn' => ['type' => 'SEOSocialLinkedIn'],
+            'mastodon' => ['type' => 'SEOSocialMastodon'],
             'mySpace' => ['type' => 'SEOSocialMySpace'],
             'pinterest' => ['type' => 'SEOSocialPinterest'],
             'youTube' => ['type' => 'SEOSocialYoutube'],
@@ -274,6 +339,16 @@ add_action('graphql_register_types', function () {
         'fields' => [
             'defaultImage' => ['type' => 'MediaItem'],
             'frontPage' => ['type' => 'SEOOpenGraphFrontPage'],
+            'enabled' => ['type' => 'Boolean'],
+        ],
+    ]);
+
+    register_graphql_object_type('SEOSocialArchive', [
+        'description' => __('The Yoast SEO Premium social settings for an archive', 'wp-graphql-yoast-seo'),
+        'fields' => [
+            'title' => ['type' => 'String'],
+            'description' => ['type' => 'String'],
+            'image' => ['type' => 'MediaItem'],
         ],
     ]);
 
@@ -290,6 +365,8 @@ add_action('graphql_register_types', function () {
             'metaRobotsFollow' => ['type' => 'String'],
             'breadcrumbTitle' => ['type' => 'String'],
             'fullHead' => ['type' => 'String'],
+            'head' => ['type' => 'SEOHead'],
+            'social' => ['type' => 'SEOSocialArchive'],
         ],
     ]);
     register_graphql_object_type('SEOContentType', [
@@ -299,6 +376,7 @@ add_action('graphql_register_types', function () {
             'metaDesc' => ['type' => 'String'],
             'metaRobotsNoindex' => ['type' => 'Boolean'],
             'schemaType' => ['type' => 'String'],
+            'articleType' => ['type' => 'String'],
             'schema' => ['type' => 'SEOPageInfoSchema'],
             'archive' => ['type' => 'SEOContentTypeArchive'],
         ],
@@ -315,6 +393,7 @@ add_action('graphql_register_types', function () {
             'title' => ['type' => 'String'],
             'metaDesc' => ['type' => 'String'],
             'metaRobotsNoindex' => ['type' => 'Boolean'],
+            'social' => ['type' => 'SEOSocialArchive'],
         ],
     ]);
     register_graphql_object_type('SEOTaxonomyType', [
@@ -327,6 +406,21 @@ add_action('graphql_register_types', function () {
     register_graphql_object_type('SEOTaxonomyTypes', [
         'description' => __('The Yoast SEO archive configuration data for taxonomies', 'wp-graphql-yoast-seo'),
         'fields' => $allTaxonomies,
+    ]);
+
+    register_graphql_object_type('SEOAdvanced', [
+        'description' => __('The Yoast SEO advanced site configuration', 'wp-graphql-yoast-seo'),
+        'fields' => [
+            'siteType' => ['type' => 'String'],
+            'environmentType' => ['type' => 'String'],
+            'hasMultipleAuthors' => ['type' => 'Boolean'],
+            'xmlSitemapEnabled' => ['type' => 'Boolean'],
+            'indexNowEnabled' => ['type' => 'Boolean'],
+            'indexNowKey' => ['type' => 'String'],
+            'contentAnalysisActive' => ['type' => 'Boolean'],
+            'keywordAnalysisActive' => ['type' => 'Boolean'],
+            'inclusiveLanguageAnalysisActive' => ['type' => 'Boolean'],
+        ],
     ]);
 
     register_graphql_object_type('SEOConfig', [
@@ -345,6 +439,7 @@ add_action('graphql_register_types', function () {
             'openGraph' => ['type' => 'SEOOpenGraph'],
             'contentTypes' => ['type' => 'SEOContentTypes'],
             'taxonomyArchives' => ['type' => 'SEOTaxonomyTypes'],
+            'advanced' => ['type' => 'SEOAdvanced'],
         ],
     ]);
 
@@ -359,6 +454,7 @@ add_action('graphql_register_types', function () {
             'youTube' => ['type' => 'String'],
             'soundCloud' => ['type' => 'String'],
             'wikipedia' => ['type' => 'String'],
+            'mastodon' => ['type' => 'String'],
         ],
     ]);
 
@@ -377,19 +473,29 @@ add_action('graphql_register_types', function () {
             'metaDesc' => ['type' => 'String'],
             'metaRobotsNoindex' => ['type' => 'String'],
             'metaRobotsNofollow' => ['type' => 'String'],
+            'robots' => ['type' => 'SEORobots'],
             'canonical' => ['type' => 'String'],
             'opengraphTitle' => ['type' => 'String'],
             'opengraphDescription' => ['type' => 'String'],
             'opengraphImage' => ['type' => 'MediaItem'],
+            'opengraphLocale' => ['type' => 'String'],
+            'opengraphFbAppId' => ['type' => 'String'],
+            'opengraphEnabled' => ['type' => 'Boolean'],
             'twitterImage' => ['type' => 'MediaItem'],
             'twitterTitle' => ['type' => 'String'],
             'twitterDescription' => ['type' => 'String'],
+            'twitterCreator' => ['type' => 'String'],
+            'twitterSite' => ['type' => 'String'],
             'language' => ['type' => 'String'],
             'region' => ['type' => 'String'],
             'breadcrumbTitle' => ['type' => 'String'],
             'fullHead' => ['type' => 'String'],
+            'head' => ['type' => 'SEOHead'],
+            'relNext' => ['type' => 'String'],
+            'relPrev' => ['type' => 'String'],
             'social' => ['type' => 'SEOUserSocial'],
             'schema' => ['type' => 'SEOUserSchema'],
+            'analysis' => ['type' => 'SEOAnalysis'],
         ],
     ]);
 

--- a/new.json
+++ b/new.json
@@ -1,0 +1,373 @@
+{
+  "data": {
+    "seo": {
+      "meta": {
+        "homepage": {
+          "title": "demo -",
+          "description": ""
+        },
+        "author": {
+          "title": ", Author at demo",
+          "description": ""
+        },
+        "date": {
+          "title": "- demo",
+          "description": ""
+        },
+        "config": {
+          "separator": "sc-dash"
+        },
+        "notFound": {
+          "title": "Page not found - demo",
+          "breadcrumb": "Error 404: Page not found"
+        }
+      },
+      "schema": {
+        "companyName": "",
+        "personName": null,
+        "companyOrPerson": "company",
+        "siteName": "demo",
+        "wordpressSiteName": "demo",
+        "siteUrl": "http://localhost:8000",
+        "homeUrl": "http://localhost:8000",
+        "inLanguage": "en-GB",
+        "companyLogo": null,
+        "personLogo": null,
+        "logo": null
+      },
+      "webmaster": {
+        "baiduVerify": "",
+        "googleVerify": "",
+        "msVerify": "",
+        "yandexVerify": ""
+      },
+      "social": {
+        "facebook": {
+          "url": "",
+          "defaultImage": null
+        },
+        "twitter": {
+          "username": "",
+          "cardType": "summary_large_image"
+        },
+        "instagram": {
+          "url": ""
+        },
+        "linkedIn": {
+          "url": ""
+        },
+        "mySpace": {
+          "url": ""
+        },
+        "pinterest": {
+          "url": "",
+          "metaTag": ""
+        },
+        "youTube": {
+          "url": ""
+        },
+        "wikipedia": {
+          "url": ""
+        },
+        "otherSocials": []
+      },
+      "breadcrumbs": {
+        "enabled": true,
+        "boldLast": false,
+        "showBlogPage": true,
+        "notFoundText": "Error 404: Page not found",
+        "archivePrefix": "Archives for",
+        "homeText": "Home",
+        "prefix": "",
+        "searchPrefix": "You searched for",
+        "separator": "»"
+      },
+      "openGraph": {
+        "defaultImage": null,
+        "frontPage": {
+          "title": "demo",
+          "description": "",
+          "image": null
+        }
+      },
+      "contentTypes": {
+        "post": {
+          "title": "- demo",
+          "metaDesc": "",
+          "metaRobotsNoindex": false,
+          "schemaType": "WebPage",
+          "schema": {
+            "raw": null
+          },
+          "archive": {
+            "hasArchive": false,
+            "title": null,
+            "metaDesc": null,
+            "metaRobotsNoindex": true,
+            "metaRobotsNofollow": true,
+            "metaRobotsIndex": "noindex",
+            "metaRobotsFollow": "nofollow",
+            "breadcrumbTitle": null,
+            "fullHead": ""
+          }
+        },
+        "page": {
+          "title": "- demo",
+          "metaDesc": "",
+          "metaRobotsNoindex": false,
+          "schemaType": "WebPage",
+          "schema": {
+            "raw": null
+          },
+          "archive": {
+            "hasArchive": false,
+            "title": null,
+            "metaDesc": null,
+            "metaRobotsNoindex": true,
+            "metaRobotsNofollow": true,
+            "metaRobotsIndex": "noindex",
+            "metaRobotsFollow": "nofollow",
+            "breadcrumbTitle": null,
+            "fullHead": ""
+          }
+        }
+      },
+      "taxonomyArchives": {
+        "category": {
+          "archive": {
+            "title": "Archives - demo",
+            "metaDesc": "",
+            "metaRobotsNoindex": false
+          }
+        },
+        "tag": {
+          "archive": {
+            "title": "Archives - demo",
+            "metaDesc": "",
+            "metaRobotsNoindex": false
+          }
+        }
+      }
+    },
+    "threePosts": {
+      "edges": [
+        {
+          "node": {
+            "title": "Hello world!",
+            "slug": "hello-world",
+            "seo": {
+              "title": "Hello world! - demo",
+              "metaDesc": "",
+              "focuskw": "",
+              "metaKeywords": "",
+              "metaRobotsNoindex": "index",
+              "metaRobotsNofollow": "follow",
+              "opengraphTitle": "Hello world!",
+              "opengraphUrl": "http://localhost:8000/?p=1",
+              "opengraphSiteName": "demo",
+              "opengraphType": "article",
+              "opengraphAuthor": "",
+              "opengraphPublisher": "",
+              "opengraphPublishedTime": "2025-04-26T20:22:25+00:00",
+              "opengraphModifiedTime": "",
+              "opengraphDescription": "Welcome to WordPress. This is your first post. Edit or delete it, then start writing!",
+              "opengraphImage": null,
+              "twitterTitle": "",
+              "twitterDescription": "",
+              "twitterImage": null,
+              "canonical": "http://localhost:8000/?p=1",
+              "readingTime": 0,
+              "cornerstone": false,
+              "fullHead": "<!-- This site is optimized with the Yoast SEO Premium plugin v24.2 (Yoast SEO v24.9) - https://yoast.com/wordpress/plugins/seo/ -->\n<link rel=\"canonical\" href=\"http://localhost:8000/?p=1\" />\n<meta property=\"og:locale\" content=\"en_GB\" />\n<meta property=\"og:type\" content=\"article\" />\n<meta property=\"og:title\" content=\"Hello world!\" />\n<meta property=\"og:description\" content=\"Welcome to WordPress. This is your first post. Edit or delete it, then start writing!\" />\n<meta property=\"og:url\" content=\"http://localhost:8000/?p=1\" />\n<meta property=\"og:site_name\" content=\"demo\" />\n<meta property=\"article:published_time\" content=\"2025-04-26T20:22:25+00:00\" />\n<meta name=\"author\" content=\"ash\" />\n<meta name=\"twitter:card\" content=\"summary_large_image\" />\n<meta name=\"twitter:label1\" content=\"Written by\" />\n\t<meta name=\"twitter:data1\" content=\"ash\" />\n<script type=\"application/ld+json\" class=\"yoast-schema-graph\">{\n\t    \"@context\": \"https://schema.org\",\n\t    \"@graph\": [\n\t        {\n\t            \"@type\": \"WebPage\",\n\t            \"@id\": \"http://localhost:8000/?p=1\",\n\t            \"url\": \"http://localhost:8000/?p=1\",\n\t            \"name\": \"Hello world! - demo\",\n\t            \"isPartOf\": {\n\t                \"@id\": \"http://localhost:8000/#website\"\n\t            },\n\t            \"datePublished\": \"2025-04-26T20:22:25+00:00\",\n\t            \"author\": {\n\t                \"@id\": \"http://localhost:8000/#/schema/person/513a30fc389bfcb4e55e243eb12e52b5\"\n\t            },\n\t            \"breadcrumb\": {\n\t                \"@id\": \"http://localhost:8000/?p=1#breadcrumb\"\n\t            },\n\t            \"inLanguage\": \"en-GB\",\n\t            \"potentialAction\": [\n\t                {\n\t                    \"@type\": \"ReadAction\",\n\t                    \"target\": [\n\t                        \"http://localhost:8000/?p=1\"\n\t                    ]\n\t                }\n\t            ]\n\t        },\n\t        {\n\t            \"@type\": \"BreadcrumbList\",\n\t            \"@id\": \"http://localhost:8000/?p=1#breadcrumb\",\n\t            \"itemListElement\": [\n\t                {\n\t                    \"@type\": \"ListItem\",\n\t                    \"position\": 1,\n\t                    \"name\": \"Home\",\n\t                    \"item\": \"http://localhost:8000/\"\n\t                },\n\t                {\n\t                    \"@type\": \"ListItem\",\n\t                    \"position\": 2,\n\t                    \"name\": \"Hello world!\"\n\t                }\n\t            ]\n\t        },\n\t        {\n\t            \"@type\": \"WebSite\",\n\t            \"@id\": \"http://localhost:8000/#website\",\n\t            \"url\": \"http://localhost:8000/\",\n\t            \"name\": \"demo\",\n\t            \"description\": \"\",\n\t            \"potentialAction\": [\n\t                {\n\t                    \"@type\": \"SearchAction\",\n\t                    \"target\": {\n\t                        \"@type\": \"EntryPoint\",\n\t                        \"urlTemplate\": \"http://localhost:8000/?s={search_term_string}\"\n\t                    },\n\t                    \"query-input\": {\n\t                        \"@type\": \"PropertyValueSpecification\",\n\t                        \"valueRequired\": true,\n\t                        \"valueName\": \"search_term_string\"\n\t                    }\n\t                }\n\t            ],\n\t            \"inLanguage\": \"en-GB\"\n\t        },\n\t        {\n\t            \"@type\": \"Person\",\n\t            \"@id\": \"http://localhost:8000/#/schema/person/513a30fc389bfcb4e55e243eb12e52b5\",\n\t            \"name\": \"ash\",\n\t            \"image\": {\n\t                \"@type\": \"ImageObject\",\n\t                \"inLanguage\": \"en-GB\",\n\t                \"@id\": \"http://localhost:8000/#/schema/person/image/\",\n\t                \"url\": \"https://secure.gravatar.com/avatar/9867960c8bbba397d3da2f9c5dea673dd7cd2b056a3db1fa1a9e0a7a852787c5?s=96&d=mm&r=g\",\n\t                \"contentUrl\": \"https://secure.gravatar.com/avatar/9867960c8bbba397d3da2f9c5dea673dd7cd2b056a3db1fa1a9e0a7a852787c5?s=96&d=mm&r=g\",\n\t                \"caption\": \"ash\"\n\t            },\n\t            \"sameAs\": [\n\t                \"http://localhost:8000\"\n\t            ],\n\t            \"url\": \"http://localhost:8000/?author=1\"\n\t        }\n\t    ]\n\t}</script>\n<!-- / Yoast SEO Premium plugin. -->",
+              "breadcrumbs": [
+                {
+                  "url": "http://localhost:8000/",
+                  "text": "Home"
+                },
+                {
+                  "url": "http://localhost:8000/?p=1",
+                  "text": "Hello world!"
+                }
+              ],
+              "schema": {
+                "pageType": [
+                  "WebPage"
+                ],
+                "articleType": [],
+                "raw": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"@id\":\"http://localhost:8000/?p=1\",\"url\":\"http://localhost:8000/?p=1\",\"name\":\"Hello world! - demo\",\"isPartOf\":{\"@id\":\"http://localhost:8000/#website\"},\"datePublished\":\"2025-04-26T20:22:25+00:00\",\"author\":{\"@id\":\"http://localhost:8000/#/schema/person/513a30fc389bfcb4e55e243eb12e52b5\"},\"breadcrumb\":{\"@id\":\"http://localhost:8000/?p=1#breadcrumb\"},\"inLanguage\":\"en-GB\",\"potentialAction\":[{\"@type\":\"ReadAction\",\"target\":[\"http://localhost:8000/?p=1\"]}]},{\"@type\":\"BreadcrumbList\",\"@id\":\"http://localhost:8000/?p=1#breadcrumb\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Home\",\"item\":\"http://localhost:8000/\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Hello world!\"}]},{\"@type\":\"WebSite\",\"@id\":\"http://localhost:8000/#website\",\"url\":\"http://localhost:8000/\",\"name\":\"demo\",\"description\":\"\",\"potentialAction\":[{\"@type\":\"SearchAction\",\"target\":{\"@type\":\"EntryPoint\",\"urlTemplate\":\"http://localhost:8000/?s={search_term_string}\"},\"query-input\":{\"@type\":\"PropertyValueSpecification\",\"valueRequired\":true,\"valueName\":\"search_term_string\"}}],\"inLanguage\":\"en-GB\"},{\"@type\":\"Person\",\"@id\":\"http://localhost:8000/#/schema/person/513a30fc389bfcb4e55e243eb12e52b5\",\"name\":\"ash\",\"image\":{\"@type\":\"ImageObject\",\"inLanguage\":\"en-GB\",\"@id\":\"http://localhost:8000/#/schema/person/image/\",\"url\":\"https://secure.gravatar.com/avatar/9867960c8bbba397d3da2f9c5dea673dd7cd2b056a3db1fa1a9e0a7a852787c5?s=96&d=mm&r=g\",\"contentUrl\":\"https://secure.gravatar.com/avatar/9867960c8bbba397d3da2f9c5dea673dd7cd2b056a3db1fa1a9e0a7a852787c5?s=96&d=mm&r=g\",\"caption\":\"ash\"},\"sameAs\":[\"http://localhost:8000\"],\"url\":\"http://localhost:8000/?author=1\"}]}"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "pages": {
+      "edges": [
+        {
+          "node": {
+            "title": "Sample Page",
+            "slug": "sample-page",
+            "seo": {
+              "title": "Sample Page - demo",
+              "metaDesc": "",
+              "focuskw": "",
+              "metaKeywords": "",
+              "metaRobotsNoindex": "index",
+              "metaRobotsNofollow": "follow",
+              "opengraphTitle": "Sample Page",
+              "opengraphDescription": "This is an example page. It’s different from a blog post because it will stay in one place and will show up in your site navigation (in most themes). Most people start with an About page that introduces them to potential site visitors. It might say something like this: Hi there! I’m a bike messenger […]",
+              "opengraphImage": null,
+              "twitterTitle": "",
+              "twitterDescription": "",
+              "twitterImage": null,
+              "canonical": "http://localhost:8000/?page_id=2",
+              "readingTime": 1,
+              "cornerstone": false,
+              "fullHead": "<!-- This site is optimized with the Yoast SEO Premium plugin v24.2 (Yoast SEO v24.9) - https://yoast.com/wordpress/plugins/seo/ -->\n<link rel=\"canonical\" href=\"http://localhost:8000/?page_id=2\" />\n<meta property=\"og:locale\" content=\"en_GB\" />\n<meta property=\"og:type\" content=\"article\" />\n<meta property=\"og:title\" content=\"Sample Page\" />\n<meta property=\"og:description\" content=\"This is an example page. It&#8217;s different from a blog post because it will stay in one place and will show up in your site navigation (in most themes). Most people start with an About page that introduces them to potential site visitors. It might say something like this: Hi there! I&#8217;m a bike messenger [&hellip;]\" />\n<meta property=\"og:url\" content=\"http://localhost:8000/?page_id=2\" />\n<meta property=\"og:site_name\" content=\"demo\" />\n<meta name=\"twitter:card\" content=\"summary_large_image\" />\n<meta name=\"twitter:label1\" content=\"Estimated reading time\" />\n\t<meta name=\"twitter:data1\" content=\"1 minute\" />\n<script type=\"application/ld+json\" class=\"yoast-schema-graph\">{\n\t    \"@context\": \"https://schema.org\",\n\t    \"@graph\": [\n\t        {\n\t            \"@type\": \"WebPage\",\n\t            \"@id\": \"http://localhost:8000/?page_id=2\",\n\t            \"url\": \"http://localhost:8000/?page_id=2\",\n\t            \"name\": \"Sample Page - demo\",\n\t            \"isPartOf\": {\n\t                \"@id\": \"http://localhost:8000/#website\"\n\t            },\n\t            \"datePublished\": \"2025-04-26T20:22:25+00:00\",\n\t            \"breadcrumb\": {\n\t                \"@id\": \"http://localhost:8000/?page_id=2#breadcrumb\"\n\t            },\n\t            \"inLanguage\": \"en-GB\",\n\t            \"potentialAction\": [\n\t                {\n\t                    \"@type\": \"ReadAction\",\n\t                    \"target\": [\n\t                        \"http://localhost:8000/?page_id=2\"\n\t                    ]\n\t                }\n\t            ]\n\t        },\n\t        {\n\t            \"@type\": \"BreadcrumbList\",\n\t            \"@id\": \"http://localhost:8000/?page_id=2#breadcrumb\",\n\t            \"itemListElement\": [\n\t                {\n\t                    \"@type\": \"ListItem\",\n\t                    \"position\": 1,\n\t                    \"name\": \"Home\",\n\t                    \"item\": \"http://localhost:8000/\"\n\t                },\n\t                {\n\t                    \"@type\": \"ListItem\",\n\t                    \"position\": 2,\n\t                    \"name\": \"Sample Page\"\n\t                }\n\t            ]\n\t        },\n\t        {\n\t            \"@type\": \"WebSite\",\n\t            \"@id\": \"http://localhost:8000/#website\",\n\t            \"url\": \"http://localhost:8000/\",\n\t            \"name\": \"demo\",\n\t            \"description\": \"\",\n\t            \"potentialAction\": [\n\t                {\n\t                    \"@type\": \"SearchAction\",\n\t                    \"target\": {\n\t                        \"@type\": \"EntryPoint\",\n\t                        \"urlTemplate\": \"http://localhost:8000/?s={search_term_string}\"\n\t                    },\n\t                    \"query-input\": {\n\t                        \"@type\": \"PropertyValueSpecification\",\n\t                        \"valueRequired\": true,\n\t                        \"valueName\": \"search_term_string\"\n\t                    }\n\t                }\n\t            ],\n\t            \"inLanguage\": \"en-GB\"\n\t        }\n\t    ]\n\t}</script>\n<!-- / Yoast SEO Premium plugin. -->",
+              "breadcrumbs": [
+                {
+                  "url": "http://localhost:8000/",
+                  "text": "Home"
+                },
+                {
+                  "url": "http://localhost:8000/?page_id=2",
+                  "text": "Sample Page"
+                }
+              ],
+              "schema": {
+                "pageType": [
+                  "WebPage"
+                ],
+                "articleType": [],
+                "raw": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"@id\":\"http://localhost:8000/?page_id=2\",\"url\":\"http://localhost:8000/?page_id=2\",\"name\":\"Sample Page - demo\",\"isPartOf\":{\"@id\":\"http://localhost:8000/#website\"},\"datePublished\":\"2025-04-26T20:22:25+00:00\",\"breadcrumb\":{\"@id\":\"http://localhost:8000/?page_id=2#breadcrumb\"},\"inLanguage\":\"en-GB\",\"potentialAction\":[{\"@type\":\"ReadAction\",\"target\":[\"http://localhost:8000/?page_id=2\"]}]},{\"@type\":\"BreadcrumbList\",\"@id\":\"http://localhost:8000/?page_id=2#breadcrumb\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Home\",\"item\":\"http://localhost:8000/\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sample Page\"}]},{\"@type\":\"WebSite\",\"@id\":\"http://localhost:8000/#website\",\"url\":\"http://localhost:8000/\",\"name\":\"demo\",\"description\":\"\",\"potentialAction\":[{\"@type\":\"SearchAction\",\"target\":{\"@type\":\"EntryPoint\",\"urlTemplate\":\"http://localhost:8000/?s={search_term_string}\"},\"query-input\":{\"@type\":\"PropertyValueSpecification\",\"valueRequired\":true,\"valueName\":\"search_term_string\"}}],\"inLanguage\":\"en-GB\"}]}"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "categories": {
+      "edges": [
+        {
+          "node": {
+            "name": "Uncategorised",
+            "slug": "uncategorised",
+            "seo": {
+              "title": "Uncategorised Archives - demo",
+              "metaDesc": "",
+              "focuskw": "",
+              "metaKeywords": null,
+              "metaRobotsNoindex": "index",
+              "metaRobotsNofollow": "follow",
+              "opengraphTitle": "Uncategorised Archives",
+              "opengraphUrl": "http://localhost:8000/?cat=1",
+              "opengraphSiteName": "demo",
+              "opengraphType": "article",
+              "opengraphAuthor": "",
+              "opengraphPublisher": "",
+              "opengraphPublishedTime": "",
+              "opengraphModifiedTime": "",
+              "opengraphDescription": "",
+              "opengraphImage": null,
+              "twitterTitle": "",
+              "twitterDescription": "",
+              "twitterImage": null,
+              "canonical": "http://localhost:8000/?cat=1",
+              "cornerstone": false,
+              "fullHead": "<!-- This site is optimized with the Yoast SEO Premium plugin v24.2 (Yoast SEO v24.9) - https://yoast.com/wordpress/plugins/seo/ -->\n<link rel=\"canonical\" href=\"http://localhost:8000/?cat=1\" />\n<meta property=\"og:locale\" content=\"en_GB\" />\n<meta property=\"og:type\" content=\"article\" />\n<meta property=\"og:title\" content=\"Uncategorised Archives\" />\n<meta property=\"og:url\" content=\"http://localhost:8000/?cat=1\" />\n<meta property=\"og:site_name\" content=\"demo\" />\n<meta name=\"twitter:card\" content=\"summary_large_image\" />\n<script type=\"application/ld+json\" class=\"yoast-schema-graph\">{\n\t    \"@context\": \"https://schema.org\",\n\t    \"@graph\": [\n\t        {\n\t            \"@type\": \"CollectionPage\",\n\t            \"@id\": \"http://localhost:8000/?cat=1\",\n\t            \"url\": \"http://localhost:8000/?cat=1\",\n\t            \"name\": \"Uncategorised Archives - demo\",\n\t            \"isPartOf\": {\n\t                \"@id\": \"http://localhost:8000/#website\"\n\t            },\n\t            \"breadcrumb\": {\n\t                \"@id\": \"http://localhost:8000/?cat=1#breadcrumb\"\n\t            },\n\t            \"inLanguage\": \"en-GB\"\n\t        },\n\t        {\n\t            \"@type\": \"BreadcrumbList\",\n\t            \"@id\": \"http://localhost:8000/?cat=1#breadcrumb\",\n\t            \"itemListElement\": [\n\t                {\n\t                    \"@type\": \"ListItem\",\n\t                    \"position\": 1,\n\t                    \"name\": \"Home\",\n\t                    \"item\": \"http://localhost:8000/\"\n\t                },\n\t                {\n\t                    \"@type\": \"ListItem\",\n\t                    \"position\": 2,\n\t                    \"name\": \"Uncategorised\"\n\t                }\n\t            ]\n\t        },\n\t        {\n\t            \"@type\": \"WebSite\",\n\t            \"@id\": \"http://localhost:8000/#website\",\n\t            \"url\": \"http://localhost:8000/\",\n\t            \"name\": \"demo\",\n\t            \"description\": \"\",\n\t            \"potentialAction\": [\n\t                {\n\t                    \"@type\": \"SearchAction\",\n\t                    \"target\": {\n\t                        \"@type\": \"EntryPoint\",\n\t                        \"urlTemplate\": \"http://localhost:8000/?s={search_term_string}\"\n\t                    },\n\t                    \"query-input\": {\n\t                        \"@type\": \"PropertyValueSpecification\",\n\t                        \"valueRequired\": true,\n\t                        \"valueName\": \"search_term_string\"\n\t                    }\n\t                }\n\t            ],\n\t            \"inLanguage\": \"en-GB\"\n\t        }\n\t    ]\n\t}</script>\n<!-- / Yoast SEO Premium plugin. -->",
+              "breadcrumbs": [
+                {
+                  "url": "http://localhost:8000/",
+                  "text": "Home"
+                },
+                {
+                  "url": "http://localhost:8000/?cat=1",
+                  "text": "Uncategorised"
+                }
+              ],
+              "schema": {
+                "raw": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"@id\":\"http://localhost:8000/?cat=1\",\"url\":\"http://localhost:8000/?cat=1\",\"name\":\"Uncategorised Archives - demo\",\"isPartOf\":{\"@id\":\"http://localhost:8000/#website\"},\"breadcrumb\":{\"@id\":\"http://localhost:8000/?cat=1#breadcrumb\"},\"inLanguage\":\"en-GB\"},{\"@type\":\"BreadcrumbList\",\"@id\":\"http://localhost:8000/?cat=1#breadcrumb\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Home\",\"item\":\"http://localhost:8000/\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Uncategorised\"}]},{\"@type\":\"WebSite\",\"@id\":\"http://localhost:8000/#website\",\"url\":\"http://localhost:8000/\",\"name\":\"demo\",\"description\":\"\",\"potentialAction\":[{\"@type\":\"SearchAction\",\"target\":{\"@type\":\"EntryPoint\",\"urlTemplate\":\"http://localhost:8000/?s={search_term_string}\"},\"query-input\":{\"@type\":\"PropertyValueSpecification\",\"valueRequired\":true,\"valueName\":\"search_term_string\"}}],\"inLanguage\":\"en-GB\"}]}"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "tags": {
+      "edges": []
+    },
+    "users": {
+      "edges": [
+        {
+          "node": {
+            "name": "ash",
+            "email": null,
+            "seo": {
+              "title": "ash, Author at demo",
+              "metaDesc": "",
+              "metaRobotsNoindex": "index",
+              "metaRobotsNofollow": "follow",
+              "canonical": "http://localhost:8000/?author=1",
+              "opengraphTitle": "ash",
+              "opengraphDescription": "",
+              "opengraphImage": null,
+              "twitterImage": null,
+              "twitterTitle": "",
+              "twitterDescription": "",
+              "language": null,
+              "region": null,
+              "breadcrumbTitle": null,
+              "fullHead": "<!-- This site is optimized with the Yoast SEO Premium plugin v24.2 (Yoast SEO v24.9) - https://yoast.com/wordpress/plugins/seo/ -->\n<link rel=\"canonical\" href=\"http://localhost:8000/?author=1\" />\n<meta property=\"og:locale\" content=\"en_GB\" />\n<meta property=\"og:type\" content=\"profile\" />\n<meta property=\"og:title\" content=\"ash\" />\n<meta property=\"og:url\" content=\"http://localhost:8000/?author=1\" />\n<meta property=\"og:site_name\" content=\"demo\" />\n<meta property=\"og:image\" content=\"https://secure.gravatar.com/avatar/9867960c8bbba397d3da2f9c5dea673dd7cd2b056a3db1fa1a9e0a7a852787c5?s=500&d=mm&r=g\" />\n<meta name=\"twitter:card\" content=\"summary_large_image\" />\n<script type=\"application/ld+json\" class=\"yoast-schema-graph\">{\n\t    \"@context\": \"https://schema.org\",\n\t    \"@graph\": [\n\t        {\n\t            \"@type\": \"ProfilePage\",\n\t            \"@id\": \"http://localhost:8000/?author=1\",\n\t            \"url\": \"http://localhost:8000/?author=1\",\n\t            \"name\": \"ash, Author at demo\",\n\t            \"isPartOf\": {\n\t                \"@id\": \"http://localhost:8000/#website\"\n\t            },\n\t            \"breadcrumb\": {\n\t                \"@id\": \"http://localhost:8000/?author=1#breadcrumb\"\n\t            },\n\t            \"inLanguage\": \"en-GB\",\n\t            \"potentialAction\": [\n\t                {\n\t                    \"@type\": \"ReadAction\",\n\t                    \"target\": [\n\t                        \"http://localhost:8000/?author=1\"\n\t                    ]\n\t                }\n\t            ]\n\t        },\n\t        {\n\t            \"@type\": \"BreadcrumbList\",\n\t            \"@id\": \"http://localhost:8000/?author=1#breadcrumb\",\n\t            \"itemListElement\": [\n\t                {\n\t                    \"@type\": \"ListItem\",\n\t                    \"position\": 1,\n\t                    \"name\": \"Home\",\n\t                    \"item\": \"http://localhost:8000/\"\n\t                },\n\t                {\n\t                    \"@type\": \"ListItem\",\n\t                    \"position\": 2,\n\t                    \"name\": \"Archives for ash\"\n\t                }\n\t            ]\n\t        },\n\t        {\n\t            \"@type\": \"WebSite\",\n\t            \"@id\": \"http://localhost:8000/#website\",\n\t            \"url\": \"http://localhost:8000/\",\n\t            \"name\": \"demo\",\n\t            \"description\": \"\",\n\t            \"potentialAction\": [\n\t                {\n\t                    \"@type\": \"SearchAction\",\n\t                    \"target\": {\n\t                        \"@type\": \"EntryPoint\",\n\t                        \"urlTemplate\": \"http://localhost:8000/?s={search_term_string}\"\n\t                    },\n\t                    \"query-input\": {\n\t                        \"@type\": \"PropertyValueSpecification\",\n\t                        \"valueRequired\": true,\n\t                        \"valueName\": \"search_term_string\"\n\t                    }\n\t                }\n\t            ],\n\t            \"inLanguage\": \"en-GB\"\n\t        },\n\t        {\n\t            \"@type\": \"Person\",\n\t            \"@id\": \"http://localhost:8000/#/schema/person/513a30fc389bfcb4e55e243eb12e52b5\",\n\t            \"name\": \"ash\",\n\t            \"image\": {\n\t                \"@type\": \"ImageObject\",\n\t                \"inLanguage\": \"en-GB\",\n\t                \"@id\": \"http://localhost:8000/#/schema/person/image/\",\n\t                \"url\": \"https://secure.gravatar.com/avatar/9867960c8bbba397d3da2f9c5dea673dd7cd2b056a3db1fa1a9e0a7a852787c5?s=96&d=mm&r=g\",\n\t                \"contentUrl\": \"https://secure.gravatar.com/avatar/9867960c8bbba397d3da2f9c5dea673dd7cd2b056a3db1fa1a9e0a7a852787c5?s=96&d=mm&r=g\",\n\t                \"caption\": \"ash\"\n\t            },\n\t            \"sameAs\": [\n\t                \"http://localhost:8000\"\n\t            ],\n\t            \"mainEntityOfPage\": {\n\t                \"@id\": \"http://localhost:8000/?author=1\"\n\t            }\n\t        }\n\t    ]\n\t}</script>\n<!-- / Yoast SEO Premium plugin. -->",
+              "social": {
+                "facebook": "",
+                "twitter": "",
+                "instagram": "",
+                "linkedIn": "",
+                "mySpace": "",
+                "pinterest": "",
+                "youTube": "",
+                "soundCloud": "",
+                "wikipedia": ""
+              },
+              "schema": {
+                "raw": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"ProfilePage\",\"@id\":\"http://localhost:8000/?author=1\",\"url\":\"http://localhost:8000/?author=1\",\"name\":\"ash, Author at demo\",\"isPartOf\":{\"@id\":\"http://localhost:8000/#website\"},\"breadcrumb\":{\"@id\":\"http://localhost:8000/?author=1#breadcrumb\"},\"inLanguage\":\"en-GB\",\"potentialAction\":[{\"@type\":\"ReadAction\",\"target\":[\"http://localhost:8000/?author=1\"]}]},{\"@type\":\"BreadcrumbList\",\"@id\":\"http://localhost:8000/?author=1#breadcrumb\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Home\",\"item\":\"http://localhost:8000/\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Archives for ash\"}]},{\"@type\":\"WebSite\",\"@id\":\"http://localhost:8000/#website\",\"url\":\"http://localhost:8000/\",\"name\":\"demo\",\"description\":\"\",\"potentialAction\":[{\"@type\":\"SearchAction\",\"target\":{\"@type\":\"EntryPoint\",\"urlTemplate\":\"http://localhost:8000/?s={search_term_string}\"},\"query-input\":{\"@type\":\"PropertyValueSpecification\",\"valueRequired\":true,\"valueName\":\"search_term_string\"}}],\"inLanguage\":\"en-GB\"},{\"@type\":\"Person\",\"@id\":\"http://localhost:8000/#/schema/person/513a30fc389bfcb4e55e243eb12e52b5\",\"name\":\"ash\",\"image\":{\"@type\":\"ImageObject\",\"inLanguage\":\"en-GB\",\"@id\":\"http://localhost:8000/#/schema/person/image/\",\"url\":\"https://secure.gravatar.com/avatar/9867960c8bbba397d3da2f9c5dea673dd7cd2b056a3db1fa1a9e0a7a852787c5?s=96&d=mm&r=g\",\"contentUrl\":\"https://secure.gravatar.com/avatar/9867960c8bbba397d3da2f9c5dea673dd7cd2b056a3db1fa1a9e0a7a852787c5?s=96&d=mm&r=g\",\"caption\":\"ash\"},\"sameAs\":[\"http://localhost:8000\"],\"mainEntityOfPage\":{\"@id\":\"http://localhost:8000/?author=1\"}}]}",
+                "pageType": [],
+                "articleType": [
+                  "Article",
+                  ""
+                ]
+              }
+            }
+          }
+        }
+      ]
+    },
+    "postsCat": {
+      "edges": [
+        {
+          "node": {
+            "title": "Hello world!",
+            "categories": {
+              "edges": [
+                {
+                  "isPrimary": false,
+                  "node": {
+                    "name": "Uncategorised"
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  },
+  "extensions": {
+    "debug": [
+      {
+        "type": "DEBUG_LOGS_INACTIVE",
+        "message": "GraphQL Debug logging is not active. To see debug logs, GRAPHQL_DEBUG must be enabled."
+      }
+    ]
+  }
+}

--- a/old.json
+++ b/old.json
@@ -1,0 +1,373 @@
+{
+  "data": {
+    "seo": {
+      "meta": {
+        "homepage": {
+          "title": "demo -",
+          "description": ""
+        },
+        "author": {
+          "title": ", Author at demo",
+          "description": ""
+        },
+        "date": {
+          "title": "- demo",
+          "description": ""
+        },
+        "config": {
+          "separator": "sc-dash"
+        },
+        "notFound": {
+          "title": "Page not found - demo",
+          "breadcrumb": "Error 404: Page not found"
+        }
+      },
+      "schema": {
+        "companyName": "",
+        "personName": null,
+        "companyOrPerson": "company",
+        "siteName": "demo",
+        "wordpressSiteName": "demo",
+        "siteUrl": "http://localhost:8000",
+        "homeUrl": "http://localhost:8000",
+        "inLanguage": "en-GB",
+        "companyLogo": null,
+        "personLogo": null,
+        "logo": null
+      },
+      "webmaster": {
+        "baiduVerify": "",
+        "googleVerify": "",
+        "msVerify": "",
+        "yandexVerify": ""
+      },
+      "social": {
+        "facebook": {
+          "url": "",
+          "defaultImage": null
+        },
+        "twitter": {
+          "username": "",
+          "cardType": "summary_large_image"
+        },
+        "instagram": {
+          "url": ""
+        },
+        "linkedIn": {
+          "url": ""
+        },
+        "mySpace": {
+          "url": ""
+        },
+        "pinterest": {
+          "url": "",
+          "metaTag": ""
+        },
+        "youTube": {
+          "url": ""
+        },
+        "wikipedia": {
+          "url": ""
+        },
+        "otherSocials": []
+      },
+      "breadcrumbs": {
+        "enabled": true,
+        "boldLast": false,
+        "showBlogPage": true,
+        "notFoundText": "Error 404: Page not found",
+        "archivePrefix": "Archives for",
+        "homeText": "Home",
+        "prefix": "",
+        "searchPrefix": "You searched for",
+        "separator": "»"
+      },
+      "openGraph": {
+        "defaultImage": null,
+        "frontPage": {
+          "title": "demo",
+          "description": "",
+          "image": null
+        }
+      },
+      "contentTypes": {
+        "post": {
+          "title": "- demo",
+          "metaDesc": "",
+          "metaRobotsNoindex": false,
+          "schemaType": "WebPage",
+          "schema": {
+            "raw": null
+          },
+          "archive": {
+            "hasArchive": false,
+            "title": null,
+            "metaDesc": null,
+            "metaRobotsNoindex": true,
+            "metaRobotsNofollow": true,
+            "metaRobotsIndex": "noindex",
+            "metaRobotsFollow": "nofollow",
+            "breadcrumbTitle": null,
+            "fullHead": ""
+          }
+        },
+        "page": {
+          "title": "- demo",
+          "metaDesc": "",
+          "metaRobotsNoindex": false,
+          "schemaType": "WebPage",
+          "schema": {
+            "raw": null
+          },
+          "archive": {
+            "hasArchive": false,
+            "title": null,
+            "metaDesc": null,
+            "metaRobotsNoindex": true,
+            "metaRobotsNofollow": true,
+            "metaRobotsIndex": "noindex",
+            "metaRobotsFollow": "nofollow",
+            "breadcrumbTitle": null,
+            "fullHead": ""
+          }
+        }
+      },
+      "taxonomyArchives": {
+        "category": {
+          "archive": {
+            "title": "Archives - demo",
+            "metaDesc": "",
+            "metaRobotsNoindex": false
+          }
+        },
+        "tag": {
+          "archive": {
+            "title": "Archives - demo",
+            "metaDesc": "",
+            "metaRobotsNoindex": false
+          }
+        }
+      }
+    },
+    "threePosts": {
+      "edges": [
+        {
+          "node": {
+            "title": "Hello world!",
+            "slug": "hello-world",
+            "seo": {
+              "title": "Hello world! - demo",
+              "metaDesc": "",
+              "focuskw": "",
+              "metaKeywords": "",
+              "metaRobotsNoindex": "index",
+              "metaRobotsNofollow": "follow",
+              "opengraphTitle": "Hello world!",
+              "opengraphUrl": "http://localhost:8000/?p=1",
+              "opengraphSiteName": "demo",
+              "opengraphType": "article",
+              "opengraphAuthor": "",
+              "opengraphPublisher": "",
+              "opengraphPublishedTime": "2025-04-26T20:22:25+00:00",
+              "opengraphModifiedTime": "",
+              "opengraphDescription": "Welcome to WordPress. This is your first post. Edit or delete it, then start writing!",
+              "opengraphImage": null,
+              "twitterTitle": "",
+              "twitterDescription": "",
+              "twitterImage": null,
+              "canonical": "http://localhost:8000/?p=1",
+              "readingTime": 0,
+              "cornerstone": false,
+              "fullHead": "<!-- This site is optimized with the Yoast SEO Premium plugin v24.2 (Yoast SEO v24.9) - https://yoast.com/wordpress/plugins/seo/ -->\n<link rel=\"canonical\" href=\"http://localhost:8000/?p=1\" />\n<meta property=\"og:locale\" content=\"en_GB\" />\n<meta property=\"og:type\" content=\"article\" />\n<meta property=\"og:title\" content=\"Hello world!\" />\n<meta property=\"og:description\" content=\"Welcome to WordPress. This is your first post. Edit or delete it, then start writing!\" />\n<meta property=\"og:url\" content=\"http://localhost:8000/?p=1\" />\n<meta property=\"og:site_name\" content=\"demo\" />\n<meta property=\"article:published_time\" content=\"2025-04-26T20:22:25+00:00\" />\n<meta name=\"author\" content=\"ash\" />\n<meta name=\"twitter:card\" content=\"summary_large_image\" />\n<meta name=\"twitter:label1\" content=\"Written by\" />\n\t<meta name=\"twitter:data1\" content=\"ash\" />\n<script type=\"application/ld+json\" class=\"yoast-schema-graph\">{\n\t    \"@context\": \"https://schema.org\",\n\t    \"@graph\": [\n\t        {\n\t            \"@type\": \"WebPage\",\n\t            \"@id\": \"http://localhost:8000/?p=1\",\n\t            \"url\": \"http://localhost:8000/?p=1\",\n\t            \"name\": \"Hello world! - demo\",\n\t            \"isPartOf\": {\n\t                \"@id\": \"http://localhost:8000/#website\"\n\t            },\n\t            \"datePublished\": \"2025-04-26T20:22:25+00:00\",\n\t            \"author\": {\n\t                \"@id\": \"http://localhost:8000/#/schema/person/513a30fc389bfcb4e55e243eb12e52b5\"\n\t            },\n\t            \"breadcrumb\": {\n\t                \"@id\": \"http://localhost:8000/?p=1#breadcrumb\"\n\t            },\n\t            \"inLanguage\": \"en-GB\",\n\t            \"potentialAction\": [\n\t                {\n\t                    \"@type\": \"ReadAction\",\n\t                    \"target\": [\n\t                        \"http://localhost:8000/?p=1\"\n\t                    ]\n\t                }\n\t            ]\n\t        },\n\t        {\n\t            \"@type\": \"BreadcrumbList\",\n\t            \"@id\": \"http://localhost:8000/?p=1#breadcrumb\",\n\t            \"itemListElement\": [\n\t                {\n\t                    \"@type\": \"ListItem\",\n\t                    \"position\": 1,\n\t                    \"name\": \"Home\",\n\t                    \"item\": \"http://localhost:8000/\"\n\t                },\n\t                {\n\t                    \"@type\": \"ListItem\",\n\t                    \"position\": 2,\n\t                    \"name\": \"Hello world!\"\n\t                }\n\t            ]\n\t        },\n\t        {\n\t            \"@type\": \"WebSite\",\n\t            \"@id\": \"http://localhost:8000/#website\",\n\t            \"url\": \"http://localhost:8000/\",\n\t            \"name\": \"demo\",\n\t            \"description\": \"\",\n\t            \"potentialAction\": [\n\t                {\n\t                    \"@type\": \"SearchAction\",\n\t                    \"target\": {\n\t                        \"@type\": \"EntryPoint\",\n\t                        \"urlTemplate\": \"http://localhost:8000/?s={search_term_string}\"\n\t                    },\n\t                    \"query-input\": {\n\t                        \"@type\": \"PropertyValueSpecification\",\n\t                        \"valueRequired\": true,\n\t                        \"valueName\": \"search_term_string\"\n\t                    }\n\t                }\n\t            ],\n\t            \"inLanguage\": \"en-GB\"\n\t        },\n\t        {\n\t            \"@type\": \"Person\",\n\t            \"@id\": \"http://localhost:8000/#/schema/person/513a30fc389bfcb4e55e243eb12e52b5\",\n\t            \"name\": \"ash\",\n\t            \"image\": {\n\t                \"@type\": \"ImageObject\",\n\t                \"inLanguage\": \"en-GB\",\n\t                \"@id\": \"http://localhost:8000/#/schema/person/image/\",\n\t                \"url\": \"https://secure.gravatar.com/avatar/9867960c8bbba397d3da2f9c5dea673dd7cd2b056a3db1fa1a9e0a7a852787c5?s=96&d=mm&r=g\",\n\t                \"contentUrl\": \"https://secure.gravatar.com/avatar/9867960c8bbba397d3da2f9c5dea673dd7cd2b056a3db1fa1a9e0a7a852787c5?s=96&d=mm&r=g\",\n\t                \"caption\": \"ash\"\n\t            },\n\t            \"sameAs\": [\n\t                \"http://localhost:8000\"\n\t            ],\n\t            \"url\": \"http://localhost:8000/?author=1\"\n\t        }\n\t    ]\n\t}</script>\n<!-- / Yoast SEO Premium plugin. -->",
+              "breadcrumbs": [
+                {
+                  "url": "http://localhost:8000/",
+                  "text": "Home"
+                },
+                {
+                  "url": "http://localhost:8000/?p=1",
+                  "text": "Hello world!"
+                }
+              ],
+              "schema": {
+                "pageType": [
+                  "WebPage"
+                ],
+                "articleType": [],
+                "raw": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"@id\":\"http://localhost:8000/?p=1\",\"url\":\"http://localhost:8000/?p=1\",\"name\":\"Hello world! - demo\",\"isPartOf\":{\"@id\":\"http://localhost:8000/#website\"},\"datePublished\":\"2025-04-26T20:22:25+00:00\",\"author\":{\"@id\":\"http://localhost:8000/#/schema/person/513a30fc389bfcb4e55e243eb12e52b5\"},\"breadcrumb\":{\"@id\":\"http://localhost:8000/?p=1#breadcrumb\"},\"inLanguage\":\"en-GB\",\"potentialAction\":[{\"@type\":\"ReadAction\",\"target\":[\"http://localhost:8000/?p=1\"]}]},{\"@type\":\"BreadcrumbList\",\"@id\":\"http://localhost:8000/?p=1#breadcrumb\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Home\",\"item\":\"http://localhost:8000/\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Hello world!\"}]},{\"@type\":\"WebSite\",\"@id\":\"http://localhost:8000/#website\",\"url\":\"http://localhost:8000/\",\"name\":\"demo\",\"description\":\"\",\"potentialAction\":[{\"@type\":\"SearchAction\",\"target\":{\"@type\":\"EntryPoint\",\"urlTemplate\":\"http://localhost:8000/?s={search_term_string}\"},\"query-input\":{\"@type\":\"PropertyValueSpecification\",\"valueRequired\":true,\"valueName\":\"search_term_string\"}}],\"inLanguage\":\"en-GB\"},{\"@type\":\"Person\",\"@id\":\"http://localhost:8000/#/schema/person/513a30fc389bfcb4e55e243eb12e52b5\",\"name\":\"ash\",\"image\":{\"@type\":\"ImageObject\",\"inLanguage\":\"en-GB\",\"@id\":\"http://localhost:8000/#/schema/person/image/\",\"url\":\"https://secure.gravatar.com/avatar/9867960c8bbba397d3da2f9c5dea673dd7cd2b056a3db1fa1a9e0a7a852787c5?s=96&d=mm&r=g\",\"contentUrl\":\"https://secure.gravatar.com/avatar/9867960c8bbba397d3da2f9c5dea673dd7cd2b056a3db1fa1a9e0a7a852787c5?s=96&d=mm&r=g\",\"caption\":\"ash\"},\"sameAs\":[\"http://localhost:8000\"],\"url\":\"http://localhost:8000/?author=1\"}]}"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "pages": {
+      "edges": [
+        {
+          "node": {
+            "title": "Sample Page",
+            "slug": "sample-page",
+            "seo": {
+              "title": "Sample Page - demo",
+              "metaDesc": "",
+              "focuskw": "",
+              "metaKeywords": "",
+              "metaRobotsNoindex": "index",
+              "metaRobotsNofollow": "follow",
+              "opengraphTitle": "Sample Page",
+              "opengraphDescription": "This is an example page. It’s different from a blog post because it will stay in one place and will show up in your site navigation (in most themes). Most people start with an About page that introduces them to potential site visitors. It might say something like this: Hi there! I’m a bike messenger […]",
+              "opengraphImage": null,
+              "twitterTitle": "",
+              "twitterDescription": "",
+              "twitterImage": null,
+              "canonical": "http://localhost:8000/?page_id=2",
+              "readingTime": 1,
+              "cornerstone": false,
+              "fullHead": "<!-- This site is optimized with the Yoast SEO Premium plugin v24.2 (Yoast SEO v24.9) - https://yoast.com/wordpress/plugins/seo/ -->\n<link rel=\"canonical\" href=\"http://localhost:8000/?page_id=2\" />\n<meta property=\"og:locale\" content=\"en_GB\" />\n<meta property=\"og:type\" content=\"article\" />\n<meta property=\"og:title\" content=\"Sample Page\" />\n<meta property=\"og:description\" content=\"This is an example page. It&#8217;s different from a blog post because it will stay in one place and will show up in your site navigation (in most themes). Most people start with an About page that introduces them to potential site visitors. It might say something like this: Hi there! I&#8217;m a bike messenger [&hellip;]\" />\n<meta property=\"og:url\" content=\"http://localhost:8000/?page_id=2\" />\n<meta property=\"og:site_name\" content=\"demo\" />\n<meta name=\"twitter:card\" content=\"summary_large_image\" />\n<meta name=\"twitter:label1\" content=\"Estimated reading time\" />\n\t<meta name=\"twitter:data1\" content=\"1 minute\" />\n<script type=\"application/ld+json\" class=\"yoast-schema-graph\">{\n\t    \"@context\": \"https://schema.org\",\n\t    \"@graph\": [\n\t        {\n\t            \"@type\": \"WebPage\",\n\t            \"@id\": \"http://localhost:8000/?page_id=2\",\n\t            \"url\": \"http://localhost:8000/?page_id=2\",\n\t            \"name\": \"Sample Page - demo\",\n\t            \"isPartOf\": {\n\t                \"@id\": \"http://localhost:8000/#website\"\n\t            },\n\t            \"datePublished\": \"2025-04-26T20:22:25+00:00\",\n\t            \"breadcrumb\": {\n\t                \"@id\": \"http://localhost:8000/?page_id=2#breadcrumb\"\n\t            },\n\t            \"inLanguage\": \"en-GB\",\n\t            \"potentialAction\": [\n\t                {\n\t                    \"@type\": \"ReadAction\",\n\t                    \"target\": [\n\t                        \"http://localhost:8000/?page_id=2\"\n\t                    ]\n\t                }\n\t            ]\n\t        },\n\t        {\n\t            \"@type\": \"BreadcrumbList\",\n\t            \"@id\": \"http://localhost:8000/?page_id=2#breadcrumb\",\n\t            \"itemListElement\": [\n\t                {\n\t                    \"@type\": \"ListItem\",\n\t                    \"position\": 1,\n\t                    \"name\": \"Home\",\n\t                    \"item\": \"http://localhost:8000/\"\n\t                },\n\t                {\n\t                    \"@type\": \"ListItem\",\n\t                    \"position\": 2,\n\t                    \"name\": \"Sample Page\"\n\t                }\n\t            ]\n\t        },\n\t        {\n\t            \"@type\": \"WebSite\",\n\t            \"@id\": \"http://localhost:8000/#website\",\n\t            \"url\": \"http://localhost:8000/\",\n\t            \"name\": \"demo\",\n\t            \"description\": \"\",\n\t            \"potentialAction\": [\n\t                {\n\t                    \"@type\": \"SearchAction\",\n\t                    \"target\": {\n\t                        \"@type\": \"EntryPoint\",\n\t                        \"urlTemplate\": \"http://localhost:8000/?s={search_term_string}\"\n\t                    },\n\t                    \"query-input\": {\n\t                        \"@type\": \"PropertyValueSpecification\",\n\t                        \"valueRequired\": true,\n\t                        \"valueName\": \"search_term_string\"\n\t                    }\n\t                }\n\t            ],\n\t            \"inLanguage\": \"en-GB\"\n\t        }\n\t    ]\n\t}</script>\n<!-- / Yoast SEO Premium plugin. -->",
+              "breadcrumbs": [
+                {
+                  "url": "http://localhost:8000/",
+                  "text": "Home"
+                },
+                {
+                  "url": "http://localhost:8000/?page_id=2",
+                  "text": "Sample Page"
+                }
+              ],
+              "schema": {
+                "pageType": [
+                  "WebPage"
+                ],
+                "articleType": [],
+                "raw": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"@id\":\"http://localhost:8000/?page_id=2\",\"url\":\"http://localhost:8000/?page_id=2\",\"name\":\"Sample Page - demo\",\"isPartOf\":{\"@id\":\"http://localhost:8000/#website\"},\"datePublished\":\"2025-04-26T20:22:25+00:00\",\"breadcrumb\":{\"@id\":\"http://localhost:8000/?page_id=2#breadcrumb\"},\"inLanguage\":\"en-GB\",\"potentialAction\":[{\"@type\":\"ReadAction\",\"target\":[\"http://localhost:8000/?page_id=2\"]}]},{\"@type\":\"BreadcrumbList\",\"@id\":\"http://localhost:8000/?page_id=2#breadcrumb\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Home\",\"item\":\"http://localhost:8000/\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sample Page\"}]},{\"@type\":\"WebSite\",\"@id\":\"http://localhost:8000/#website\",\"url\":\"http://localhost:8000/\",\"name\":\"demo\",\"description\":\"\",\"potentialAction\":[{\"@type\":\"SearchAction\",\"target\":{\"@type\":\"EntryPoint\",\"urlTemplate\":\"http://localhost:8000/?s={search_term_string}\"},\"query-input\":{\"@type\":\"PropertyValueSpecification\",\"valueRequired\":true,\"valueName\":\"search_term_string\"}}],\"inLanguage\":\"en-GB\"}]}"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "categories": {
+      "edges": [
+        {
+          "node": {
+            "name": "Uncategorised",
+            "slug": "uncategorised",
+            "seo": {
+              "title": "Uncategorised Archives - demo",
+              "metaDesc": "",
+              "focuskw": "",
+              "metaKeywords": null,
+              "metaRobotsNoindex": "index",
+              "metaRobotsNofollow": "follow",
+              "opengraphTitle": "Uncategorised Archives",
+              "opengraphUrl": "http://localhost:8000/?cat=1",
+              "opengraphSiteName": "demo",
+              "opengraphType": "article",
+              "opengraphAuthor": "",
+              "opengraphPublisher": "",
+              "opengraphPublishedTime": "",
+              "opengraphModifiedTime": "",
+              "opengraphDescription": "",
+              "opengraphImage": null,
+              "twitterTitle": "",
+              "twitterDescription": "",
+              "twitterImage": null,
+              "canonical": "http://localhost:8000/?cat=1",
+              "cornerstone": false,
+              "fullHead": "<!-- This site is optimized with the Yoast SEO Premium plugin v24.2 (Yoast SEO v24.9) - https://yoast.com/wordpress/plugins/seo/ -->\n<link rel=\"canonical\" href=\"http://localhost:8000/?cat=1\" />\n<meta property=\"og:locale\" content=\"en_GB\" />\n<meta property=\"og:type\" content=\"article\" />\n<meta property=\"og:title\" content=\"Uncategorised Archives\" />\n<meta property=\"og:url\" content=\"http://localhost:8000/?cat=1\" />\n<meta property=\"og:site_name\" content=\"demo\" />\n<meta name=\"twitter:card\" content=\"summary_large_image\" />\n<script type=\"application/ld+json\" class=\"yoast-schema-graph\">{\n\t    \"@context\": \"https://schema.org\",\n\t    \"@graph\": [\n\t        {\n\t            \"@type\": \"CollectionPage\",\n\t            \"@id\": \"http://localhost:8000/?cat=1\",\n\t            \"url\": \"http://localhost:8000/?cat=1\",\n\t            \"name\": \"Uncategorised Archives - demo\",\n\t            \"isPartOf\": {\n\t                \"@id\": \"http://localhost:8000/#website\"\n\t            },\n\t            \"breadcrumb\": {\n\t                \"@id\": \"http://localhost:8000/?cat=1#breadcrumb\"\n\t            },\n\t            \"inLanguage\": \"en-GB\"\n\t        },\n\t        {\n\t            \"@type\": \"BreadcrumbList\",\n\t            \"@id\": \"http://localhost:8000/?cat=1#breadcrumb\",\n\t            \"itemListElement\": [\n\t                {\n\t                    \"@type\": \"ListItem\",\n\t                    \"position\": 1,\n\t                    \"name\": \"Home\",\n\t                    \"item\": \"http://localhost:8000/\"\n\t                },\n\t                {\n\t                    \"@type\": \"ListItem\",\n\t                    \"position\": 2,\n\t                    \"name\": \"Uncategorised\"\n\t                }\n\t            ]\n\t        },\n\t        {\n\t            \"@type\": \"WebSite\",\n\t            \"@id\": \"http://localhost:8000/#website\",\n\t            \"url\": \"http://localhost:8000/\",\n\t            \"name\": \"demo\",\n\t            \"description\": \"\",\n\t            \"potentialAction\": [\n\t                {\n\t                    \"@type\": \"SearchAction\",\n\t                    \"target\": {\n\t                        \"@type\": \"EntryPoint\",\n\t                        \"urlTemplate\": \"http://localhost:8000/?s={search_term_string}\"\n\t                    },\n\t                    \"query-input\": {\n\t                        \"@type\": \"PropertyValueSpecification\",\n\t                        \"valueRequired\": true,\n\t                        \"valueName\": \"search_term_string\"\n\t                    }\n\t                }\n\t            ],\n\t            \"inLanguage\": \"en-GB\"\n\t        }\n\t    ]\n\t}</script>\n<!-- / Yoast SEO Premium plugin. -->",
+              "breadcrumbs": [
+                {
+                  "url": "http://localhost:8000/",
+                  "text": "Home"
+                },
+                {
+                  "url": "http://localhost:8000/?cat=1",
+                  "text": "Uncategorised"
+                }
+              ],
+              "schema": {
+                "raw": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"@id\":\"http://localhost:8000/?cat=1\",\"url\":\"http://localhost:8000/?cat=1\",\"name\":\"Uncategorised Archives - demo\",\"isPartOf\":{\"@id\":\"http://localhost:8000/#website\"},\"breadcrumb\":{\"@id\":\"http://localhost:8000/?cat=1#breadcrumb\"},\"inLanguage\":\"en-GB\"},{\"@type\":\"BreadcrumbList\",\"@id\":\"http://localhost:8000/?cat=1#breadcrumb\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Home\",\"item\":\"http://localhost:8000/\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Uncategorised\"}]},{\"@type\":\"WebSite\",\"@id\":\"http://localhost:8000/#website\",\"url\":\"http://localhost:8000/\",\"name\":\"demo\",\"description\":\"\",\"potentialAction\":[{\"@type\":\"SearchAction\",\"target\":{\"@type\":\"EntryPoint\",\"urlTemplate\":\"http://localhost:8000/?s={search_term_string}\"},\"query-input\":{\"@type\":\"PropertyValueSpecification\",\"valueRequired\":true,\"valueName\":\"search_term_string\"}}],\"inLanguage\":\"en-GB\"}]}"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "tags": {
+      "edges": []
+    },
+    "users": {
+      "edges": [
+        {
+          "node": {
+            "name": "ash",
+            "email": null,
+            "seo": {
+              "title": "ash, Author at demo",
+              "metaDesc": "",
+              "metaRobotsNoindex": "index",
+              "metaRobotsNofollow": "follow",
+              "canonical": "http://localhost:8000/?author=1",
+              "opengraphTitle": "ash",
+              "opengraphDescription": "",
+              "opengraphImage": null,
+              "twitterImage": null,
+              "twitterTitle": "",
+              "twitterDescription": "",
+              "language": null,
+              "region": null,
+              "breadcrumbTitle": null,
+              "fullHead": "<!-- This site is optimized with the Yoast SEO Premium plugin v24.2 (Yoast SEO v24.9) - https://yoast.com/wordpress/plugins/seo/ -->\n<link rel=\"canonical\" href=\"http://localhost:8000/?author=1\" />\n<meta property=\"og:locale\" content=\"en_GB\" />\n<meta property=\"og:type\" content=\"profile\" />\n<meta property=\"og:title\" content=\"ash\" />\n<meta property=\"og:url\" content=\"http://localhost:8000/?author=1\" />\n<meta property=\"og:site_name\" content=\"demo\" />\n<meta property=\"og:image\" content=\"https://secure.gravatar.com/avatar/9867960c8bbba397d3da2f9c5dea673dd7cd2b056a3db1fa1a9e0a7a852787c5?s=500&d=mm&r=g\" />\n<meta name=\"twitter:card\" content=\"summary_large_image\" />\n<script type=\"application/ld+json\" class=\"yoast-schema-graph\">{\n\t    \"@context\": \"https://schema.org\",\n\t    \"@graph\": [\n\t        {\n\t            \"@type\": \"ProfilePage\",\n\t            \"@id\": \"http://localhost:8000/?author=1\",\n\t            \"url\": \"http://localhost:8000/?author=1\",\n\t            \"name\": \"ash, Author at demo\",\n\t            \"isPartOf\": {\n\t                \"@id\": \"http://localhost:8000/#website\"\n\t            },\n\t            \"breadcrumb\": {\n\t                \"@id\": \"http://localhost:8000/?author=1#breadcrumb\"\n\t            },\n\t            \"inLanguage\": \"en-GB\",\n\t            \"potentialAction\": [\n\t                {\n\t                    \"@type\": \"ReadAction\",\n\t                    \"target\": [\n\t                        \"http://localhost:8000/?author=1\"\n\t                    ]\n\t                }\n\t            ]\n\t        },\n\t        {\n\t            \"@type\": \"BreadcrumbList\",\n\t            \"@id\": \"http://localhost:8000/?author=1#breadcrumb\",\n\t            \"itemListElement\": [\n\t                {\n\t                    \"@type\": \"ListItem\",\n\t                    \"position\": 1,\n\t                    \"name\": \"Home\",\n\t                    \"item\": \"http://localhost:8000/\"\n\t                },\n\t                {\n\t                    \"@type\": \"ListItem\",\n\t                    \"position\": 2,\n\t                    \"name\": \"Archives for ash\"\n\t                }\n\t            ]\n\t        },\n\t        {\n\t            \"@type\": \"WebSite\",\n\t            \"@id\": \"http://localhost:8000/#website\",\n\t            \"url\": \"http://localhost:8000/\",\n\t            \"name\": \"demo\",\n\t            \"description\": \"\",\n\t            \"potentialAction\": [\n\t                {\n\t                    \"@type\": \"SearchAction\",\n\t                    \"target\": {\n\t                        \"@type\": \"EntryPoint\",\n\t                        \"urlTemplate\": \"http://localhost:8000/?s={search_term_string}\"\n\t                    },\n\t                    \"query-input\": {\n\t                        \"@type\": \"PropertyValueSpecification\",\n\t                        \"valueRequired\": true,\n\t                        \"valueName\": \"search_term_string\"\n\t                    }\n\t                }\n\t            ],\n\t            \"inLanguage\": \"en-GB\"\n\t        },\n\t        {\n\t            \"@type\": \"Person\",\n\t            \"@id\": \"http://localhost:8000/#/schema/person/513a30fc389bfcb4e55e243eb12e52b5\",\n\t            \"name\": \"ash\",\n\t            \"image\": {\n\t                \"@type\": \"ImageObject\",\n\t                \"inLanguage\": \"en-GB\",\n\t                \"@id\": \"http://localhost:8000/#/schema/person/image/\",\n\t                \"url\": \"https://secure.gravatar.com/avatar/9867960c8bbba397d3da2f9c5dea673dd7cd2b056a3db1fa1a9e0a7a852787c5?s=96&d=mm&r=g\",\n\t                \"contentUrl\": \"https://secure.gravatar.com/avatar/9867960c8bbba397d3da2f9c5dea673dd7cd2b056a3db1fa1a9e0a7a852787c5?s=96&d=mm&r=g\",\n\t                \"caption\": \"ash\"\n\t            },\n\t            \"sameAs\": [\n\t                \"http://localhost:8000\"\n\t            ],\n\t            \"mainEntityOfPage\": {\n\t                \"@id\": \"http://localhost:8000/?author=1\"\n\t            }\n\t        }\n\t    ]\n\t}</script>\n<!-- / Yoast SEO Premium plugin. -->",
+              "social": {
+                "facebook": "",
+                "twitter": "",
+                "instagram": "",
+                "linkedIn": "",
+                "mySpace": "",
+                "pinterest": "",
+                "youTube": "",
+                "soundCloud": "",
+                "wikipedia": ""
+              },
+              "schema": {
+                "raw": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"ProfilePage\",\"@id\":\"http://localhost:8000/?author=1\",\"url\":\"http://localhost:8000/?author=1\",\"name\":\"ash, Author at demo\",\"isPartOf\":{\"@id\":\"http://localhost:8000/#website\"},\"breadcrumb\":{\"@id\":\"http://localhost:8000/?author=1#breadcrumb\"},\"inLanguage\":\"en-GB\",\"potentialAction\":[{\"@type\":\"ReadAction\",\"target\":[\"http://localhost:8000/?author=1\"]}]},{\"@type\":\"BreadcrumbList\",\"@id\":\"http://localhost:8000/?author=1#breadcrumb\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Home\",\"item\":\"http://localhost:8000/\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Archives for ash\"}]},{\"@type\":\"WebSite\",\"@id\":\"http://localhost:8000/#website\",\"url\":\"http://localhost:8000/\",\"name\":\"demo\",\"description\":\"\",\"potentialAction\":[{\"@type\":\"SearchAction\",\"target\":{\"@type\":\"EntryPoint\",\"urlTemplate\":\"http://localhost:8000/?s={search_term_string}\"},\"query-input\":{\"@type\":\"PropertyValueSpecification\",\"valueRequired\":true,\"valueName\":\"search_term_string\"}}],\"inLanguage\":\"en-GB\"},{\"@type\":\"Person\",\"@id\":\"http://localhost:8000/#/schema/person/513a30fc389bfcb4e55e243eb12e52b5\",\"name\":\"ash\",\"image\":{\"@type\":\"ImageObject\",\"inLanguage\":\"en-GB\",\"@id\":\"http://localhost:8000/#/schema/person/image/\",\"url\":\"https://secure.gravatar.com/avatar/9867960c8bbba397d3da2f9c5dea673dd7cd2b056a3db1fa1a9e0a7a852787c5?s=96&d=mm&r=g\",\"contentUrl\":\"https://secure.gravatar.com/avatar/9867960c8bbba397d3da2f9c5dea673dd7cd2b056a3db1fa1a9e0a7a852787c5?s=96&d=mm&r=g\",\"caption\":\"ash\"},\"sameAs\":[\"http://localhost:8000\"],\"mainEntityOfPage\":{\"@id\":\"http://localhost:8000/?author=1\"}}]}",
+                "pageType": [],
+                "articleType": [
+                  "Article",
+                  ""
+                ]
+              }
+            }
+          }
+        }
+      ]
+    },
+    "postsCat": {
+      "edges": [
+        {
+          "node": {
+            "title": "Hello world!",
+            "categories": {
+              "edges": [
+                {
+                  "isPrimary": false,
+                  "node": {
+                    "name": "Uncategorised"
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  },
+  "extensions": {
+    "debug": [
+      {
+        "type": "DEBUG_LOGS_INACTIVE",
+        "message": "GraphQL Debug logging is not active. To see debug logs, GRAPHQL_DEBUG must be enabled."
+      }
+    ]
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "wp-graphql-yoast-seo",
-    "version": "v5.0.3",
+    "version": "v5.1.0",
     "description": "A WPGraphQL Extension that adds support for Yoast SEO",
     "scripts": {
         "test": "echo \"Error: no test specified\" && exit 1",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: SEO, Yoast, WPGraphQL, GraphQL, Headless WordPress
 Requires at least: 5.0
 Tested up to: 7.0
 Requires PHP: 7.1
-Stable tag: 5.0.3
+Stable tag: 5.1.0
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -27,9 +27,19 @@ This is an extension to the WPGraphQL plugin (https://github.com/wp-graphql/wp-g
 - WooCommerce Products
 - Yoast Configuration
   - Webmaster verification
-  - Social profiles
+  - Social profiles (including Mastodon)
   - Schemas
   - Breadcrumbs
+  - Advanced robots directives (noarchive, noimageindex, nosnippet)
+  - SEO analysis scores and link counts
+  - Structured head JSON (html + json)
+  - Open Graph locale, FB App ID, enabled toggle
+  - Twitter creator/site handles, enabled toggle
+  - Pagination rel_next/rel_prev
+  - Search results, author/date archive noindex settings
+  - Schema article type per content type
+  - Sitemap, Index Now, and analysis toggles
+  - Premium: per-archive social settings (title/description/image)
 
   > Please Note: Yoast and WPGraphQL and their logos are copyright to their respective owners.
 

--- a/wp-graphql-yoast-seo.php
+++ b/wp-graphql-yoast-seo.php
@@ -8,7 +8,7 @@
  * Author URI: https://www.ashleyhitchcock.com
  * Text Domain: wp-graphql-yoast-seo
  * Domain Path: /languages
- * Version: 5.0.3
+ * Version: 5.1.0
  * Requires Plugins: wp-graphql, wordpress-seo
  * License: GPL-3.0-or-later
  * License URI: https://www.gnu.org/licenses/gpl-3.0.html
@@ -23,7 +23,7 @@ if (!defined('ABSPATH')) {
 /**
  * Define plugin constants
  */
-define('WPGRAPHQL_YOAST_SEO_VERSION', '5.0.3');
+define('WPGRAPHQL_YOAST_SEO_VERSION', '5.1.0');
 define('WPGRAPHQL_YOAST_SEO_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('WPGRAPHQL_YOAST_SEO_PLUGIN_URL', plugin_dir_url(__FILE__));
 


### PR DESCRIPTION
This pull request introduces a significant set of enhancements and fixes to the SEO GraphQL integration, focusing on richer per-object SEO data, improved global configuration, and support for Yoast SEO Premium social fields. It also adds new helper functions and updates to the changelog, along with a comprehensive test query. The most important changes are grouped below.

**Per-object SEO data improvements:**

* Added a `robots` object (with `noindex`, `nofollow`, `noarchive`, `noimageindex`, `nosnippet`) and an `analysis` object (with `keywordScore`, `readabilityScore`, `inclusiveLanguageScore`, `linkCount`, `incomingLinkCount`) to post, term, and user SEO fields. Also included new fields like `opengraphLocale`, `opengraphFbAppId`, `opengraphEnabled`, `twitterCreator`, `twitterSite`, pagination links (`relNext`, `relPrev`), and more granular metadata (e.g., `breadcrumbTitle`, `objectPublishedAt`, `language`, `region`, `mastodon` for users). [[1]](diffhunk://#diff-be06b3067c9f26d1885ba50e6bb852d82b5edb312477cc6bbace948cefe90811R49-R70) [[2]](diffhunk://#diff-be06b3067c9f26d1885ba50e6bb852d82b5edb312477cc6bbace948cefe90811R39) [[3]](diffhunk://#diff-e0246478b98314e2385f169e3f009723421fb86189b9569943b78e20555360b2R194-R337) [[4]](diffhunk://#diff-e0246478b98314e2385f169e3f009723421fb86189b9569943b78e20555360b2L150-R152)

* Introduced a structured `head` object (with both `html` and `json` fields) alongside the existing `fullHead` HTML string, matching Yoast's REST output for headless consumers.

**Global configuration and premium features:**

* Filled gaps in global config: added fields like `meta.search`, author/date noindex options, per-content-type `articleType`, and new toggles under `advanced` (e.g., `indexNowEnabled`, `contentAnalysisActive`, `inclusiveLanguageAnalysisActive`). [[1]](diffhunk://#diff-e0246478b98314e2385f169e3f009723421fb86189b9569943b78e20555360b2R363-R388) [[2]](diffhunk://#diff-e0246478b98314e2385f169e3f009723421fb86189b9569943b78e20555360b2R401-R404)

* Added support for Yoast SEO Premium social-per-archive fields via the `SEOSocialArchive` type, with graceful fallback to `null` when Premium is inactive. [[1]](diffhunk://#diff-e0246478b98314e2385f169e3f009723421fb86189b9569943b78e20555360b2R363-R388) [[2]](diffhunk://#diff-e0246478b98314e2385f169e3f009723421fb86189b9569943b78e20555360b2R401-R404) [[3]](diffhunk://#diff-e0246478b98314e2385f169e3f009723421fb86189b9569943b78e20555360b2L296-R429)

**Helper functions and code improvements:**

* Added helper functions: `wp_gql_seo_get_head_obj`, `wp_gql_seo_indexable_prop`, `wp_gql_seo_build_analysis`, `wp_gql_seo_build_robots`, and `wp_gql_seo_get_premium_social` to centralize and simplify data extraction from Yoast objects and options.

* Updated `wp_gql_seo_build_content_type_data` and `wp_gql_seo_build_taxonomy_data` to accept the GraphQL context and include new fields. [[1]](diffhunk://#diff-e0246478b98314e2385f169e3f009723421fb86189b9569943b78e20555360b2R363-R388) [[2]](diffhunk://#diff-e0246478b98314e2385f169e3f009723421fb86189b9569943b78e20555360b2R401-R404)

**Testing and documentation:**

* Added a comprehensive `all.graphql` query file to exercise all new and existing SEO fields for posts, terms, users, and global config.

* Updated `.distignore` and `CHANGELOG.md` to reflect new features and fixes. [[1]](diffhunk://#diff-7532ecfafde13213d490e590e0a75f07757afcd42b9b0c241db19051827f11d5R43) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R41)

**Bug fixes:**

* Fixed a cache N+1 issue in taxonomy resolver by caching the result of `YoastSEO()->meta->for_term()`.

These changes provide a much richer and more robust SEO data layer for consumers of the GraphQL API, with improved performance, premium feature support, and better compatibility with Yoast's own headless integrations.