### PR TITLE
fix(composer): install into add-wpgraphql-seo to match the wp.org slug

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,5 +26,8 @@
         "allow-plugins": {
             "dealerdirect/phpcodesniffer-composer-installer": true
         }
+    },
+    "extra": {
+        "installer-name": "add-wpgraphql-seo"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "391743bfdab15f1840716643e88875e4",
+    "content-hash": "903868665890db89ae79dde5eb15a0c6",
     "packages": [
         {
             "name": "phpcompatibility/php-compatibility",


### PR DESCRIPTION
Fixes the directory-name divergence described in #203.

`composer/installers` derives the install directory from the package name, so Composer installs land in `wp-content/plugins/wp-graphql-yoast-seo/`, while both the GitHub release asset and the wordpress.org zip unpack to `add-wpgraphql-seo/`. Any update applied through the WP admin therefore relocates a Composer-managed install into a second directory, leaving a duplicate and a plugin that is no longer at the path recorded in `active_plugins`.

`extra.installer-name` aligns Composer with the wp.org slug, so all three distribution channels produce `add-wpgraphql-seo/`.

### Verified

Tested against `composer/installers` v2.3.0 with a consumer using `"wp-content/plugins/{$name}/"` in `installer-paths`:

| plugin `composer.json` | install path |
|---|---|
| unchanged (`master`) | `wp-content/plugins/wp-graphql-yoast-seo/` |
| with this patch | `wp-content/plugins/add-wpgraphql-seo/` |

`composer validate` passes; the second commit only refreshes the `content-hash` in `composer.lock`, which `extra` feeds into.

### Heads-up on the direction chosen

This standardises on the **wp.org slug**. That is the choice I'd argue for — it's the name the .org repository and both zips already use, and it's the one the WP updater will impose anyway — but it does mean existing Composer users get a one-time rename on their next `composer update`, which deactivates the plugin until it is re-activated. Worth a line in `CHANGELOG.md` and the release notes.

If you'd rather standardise the other way (ship the zips with a `wp-graphql-yoast-seo/` root), that works too and this PR should be closed — but the .org slug can't be changed, so the WP-admin update path would keep pulling installs toward `add-wpgraphql-seo` and the underlying issue would remain. Happy to redo it either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
